### PR TITLE
fix: clean blocked import failure output

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,7 +5,7 @@ import { registerExportCommand } from './commands/export';
 import { registerImportCommand } from './commands/import';
 import { registerInspectCommand } from './commands/inspect';
 import { registerValidateCommand } from './commands/validate';
-import { isRenderableCliError } from './commands/import';
+import { isRenderableCliError } from './renderable-cli-error';
 
 const program = new Command();
 

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -5,6 +5,7 @@ import { discoverOpenClawConfig } from '../core/openclaw-config';
 import { planImport } from '../core/import-plan';
 import { readPackageDirectory } from '../core/package-read';
 import type { ImportPlan } from '../core/types';
+import { renderableCliErrorBrand, type RenderableCliError } from '../renderable-cli-error';
 
 interface ImportOptions {
   targetWorkspace: string;
@@ -12,10 +13,6 @@ interface ImportOptions {
   config?: string;
   force?: boolean;
   json?: boolean;
-}
-
-export interface RenderableCliError {
-  render(): string;
 }
 
 interface BlockedImportReport extends Pick<
@@ -26,6 +23,8 @@ interface BlockedImportReport extends Pick<
 }
 
 class ImportBlockedError extends Error implements RenderableCliError {
+  readonly [renderableCliErrorBrand] = true;
+
   constructor(
     readonly report: BlockedImportReport,
     private readonly asJson: boolean,
@@ -96,14 +95,6 @@ function formatBlockedImportReport(report: BlockedImportReport): string {
 
   return lines.join('\n');
 }
-
-export function isRenderableCliError(error: unknown): error is RenderableCliError {
-  return typeof error === 'object'
-    && error !== null
-    && 'render' in error
-    && typeof (error as RenderableCliError).render === 'function';
-}
-
 export async function runImport(packagePath: string, options: ImportOptions): Promise<void> {
   if (!packagePath || !options.targetWorkspace) {
     throw new Error('import requires <package-path> and --target-workspace <path>');

--- a/src/renderable-cli-error.ts
+++ b/src/renderable-cli-error.ts
@@ -1,0 +1,15 @@
+export const renderableCliErrorBrand: unique symbol = Symbol('renderableCliError');
+
+export interface RenderableCliError {
+  readonly [renderableCliErrorBrand]: true;
+  render(): string;
+}
+
+export function isRenderableCliError(error: unknown): error is RenderableCliError {
+  return typeof error === 'object'
+    && error !== null
+    && renderableCliErrorBrand in error
+    && error[renderableCliErrorBrand] === true
+    && 'render' in error
+    && typeof error.render === 'function';
+}

--- a/tests/import-command.test.ts
+++ b/tests/import-command.test.ts
@@ -37,9 +37,21 @@ async function runCliFailure(args: string[]) {
     await runCli(args);
     assert.fail(`Expected CLI invocation to fail: ${args.join(' ')}`);
   } catch (error) {
+    if (error instanceof assert.AssertionError) {
+      throw error;
+    }
+
     return error as NodeJS.ErrnoException & { stdout: string; stderr: string; code: number };
   }
 }
+
+test('runCliFailure rethrows assertion failures when the CLI succeeds', async () => {
+  await assert.rejects(
+    async () => runCliFailure(['--version']),
+    (error: unknown) => error instanceof assert.AssertionError
+      && /Expected CLI invocation to fail: --version/.test(error.message),
+  );
+});
 
 test('blocked import prints clean human-readable output and exits non-zero', async () => {
   await prepareBlockedImportFixture();


### PR DESCRIPTION
## Summary\n- replace blocked import JSON-in-Error output with structured CLI error rendering\n- keep human-readable blocked import output by default and clean JSON under --json\n- add regression coverage for both blocked import modes\n\n## Testing\n- node --import tsx --test tests/import-command.test.ts\n- npm run build\n- npm test\n\nCloses #3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **改进**
  * 提升命令行错误呈现的内部实现，统一错误渲染接口，保持现有文本与 JSON 输出行为不变。

* **测试**
  * 调整测试以保留断言失败的传播，并新增覆盖该行为的测试用例。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->