### PR TITLE
chore: add .worktrees to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 tmp/
 coverage/
 package-output/
+.worktrees


### PR DESCRIPTION
## Summary
- 将 `.worktrees` 目录加入 `.gitignore`，避免 git worktree 工作目录被意外追踪到版本控制中。


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **杂项**
  * 更新项目配置以扩展忽略路径。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->