### PR TITLE
fix: unify CLI output format across export/import/validate (#13)

### DIFF
--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -11,6 +11,7 @@ interface ExportOptions {
   name?: string;
   config?: string;
   agentId?: string;
+  json?: boolean;
 }
 
 export async function runExport(options: ExportOptions): Promise<void> {
@@ -34,18 +35,24 @@ export async function runExport(options: ExportOptions): Promise<void> {
     agentDefinition,
   });
 
-  console.log(
-    JSON.stringify(
-      {
-        status: 'ok',
-        packageRoot: result.packageRoot,
-        manifestPath: result.manifestPath,
-        fileCount: result.fileCount,
-      },
-      null,
-      2,
-    ),
-  );
+  const report = {
+    status: 'ok' as const,
+    packageRoot: result.packageRoot,
+    manifestPath: result.manifestPath,
+    fileCount: result.fileCount,
+  };
+
+  if (options.json) {
+    console.log(JSON.stringify(report, null, 2));
+    return;
+  }
+
+  console.log([
+    'Export complete',
+    `  Package: ${report.packageRoot}`,
+    `  Manifest: ${report.manifestPath}`,
+    `  Files: ${report.fileCount}`,
+  ].join('\n'));
 }
 
 export function registerExportCommand(command: Command): void {
@@ -56,5 +63,6 @@ export function registerExportCommand(command: Command): void {
     .option('--name <package-name>', 'Package name override')
     .option('--config <path>', 'OpenClaw config path')
     .option('--agent-id <id>', 'Source agent id override')
+    .option('--json', 'Emit the full machine-readable JSON report')
     .action(runExport);
 }

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -6,6 +6,7 @@ import { planImport } from '../core/import-plan';
 import { readPackageDirectory } from '../core/package-read';
 import type { ImportPlan } from '../core/types';
 import { renderableCliErrorBrand, type RenderableCliError } from '../renderable-cli-error';
+import { pushSection } from '../utils/output';
 
 interface ImportOptions {
   targetWorkspace: string;
@@ -50,14 +51,6 @@ function formatRequiredInputKey(key: BlockedImportReport['requiredInputs'][numbe
   }
 
   return key;
-}
-
-function pushSection(lines: string[], heading: string, items: string[]): void {
-  if (items.length === 0) {
-    return;
-  }
-
-  lines.push('', `${heading}:`, ...items.map((item) => `- ${item}`));
 }
 
 function formatBlockedImportReport(report: BlockedImportReport): string {
@@ -125,7 +118,24 @@ export async function runImport(packagePath: string, options: ImportOptions): Pr
   }
 
   const result = await executeImport({ pkg, plan });
-  console.log(JSON.stringify(result, null, 2));
+
+  if (options.json) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  const lines = [
+    'Import complete',
+    `  Workspace: ${result.targetWorkspacePath}`,
+    `  Agent id: ${result.agentId}`,
+    `  Imported files: ${result.importedFiles.length}`,
+    `  Metadata files: ${result.metadataFiles.length}`,
+  ];
+
+  pushSection(lines, 'Warnings', result.warnings);
+  pushSection(lines, 'Next steps', result.nextSteps);
+
+  console.log(lines.join('\n'));
 }
 
 export function registerImportCommand(command: Command): void {
@@ -136,6 +146,6 @@ export function registerImportCommand(command: Command): void {
     .option('--agent-id <id>', 'Target agent id override')
     .option('--config <path>', 'Target OpenClaw config path')
     .option('--force', 'Overwrite an existing target workspace')
-    .option('--json', 'Emit blocked import details as JSON on failure')
+    .option('--json', 'Emit the full machine-readable JSON report')
     .action(runImport);
 }

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -1,11 +1,13 @@
 import path from 'node:path';
 import type { Command } from 'commander';
 import { validateImportedWorkspace } from '../core/validate';
+import { pushSection } from '../utils/output';
 
 interface ValidateOptions {
   targetWorkspace: string;
   agentId?: string;
   config?: string;
+  json?: boolean;
 }
 
 export async function runValidate(options: ValidateOptions): Promise<void> {
@@ -19,7 +21,21 @@ export async function runValidate(options: ValidateOptions): Promise<void> {
     targetConfigPath: options.config ? path.resolve(options.config) : undefined,
   });
 
-  console.log(JSON.stringify(report, null, 2));
+  if (options.json) {
+    console.log(JSON.stringify(report, null, 2));
+    return;
+  }
+
+  const lines = [
+    `Validation: ${report.failed.length === 0 ? 'passed' : 'FAILED'}`,
+  ];
+
+  pushSection(lines, 'Passed', report.passed);
+  pushSection(lines, 'Warnings', report.warnings);
+  pushSection(lines, 'Failed', report.failed);
+  pushSection(lines, 'Next steps', report.nextSteps);
+
+  console.log(lines.join('\n'));
 }
 
 export function registerValidateCommand(command: Command): void {
@@ -28,5 +44,6 @@ export function registerValidateCommand(command: Command): void {
     .requiredOption('--target-workspace <path>', 'Imported target workspace path')
     .option('--agent-id <id>', 'Expected target agent id')
     .option('--config <path>', 'Target OpenClaw config path for consistency checks')
+    .option('--json', 'Emit the full machine-readable JSON report')
     .action(runValidate);
 }

--- a/src/utils/output.ts
+++ b/src/utils/output.ts
@@ -1,0 +1,11 @@
+/**
+ * Appends a labelled section to a lines array when items are non-empty.
+ * Shared across command formatters to keep section rendering consistent.
+ */
+export function pushSection(lines: string[], heading: string, items: string[]): void {
+  if (items.length === 0) {
+    return;
+  }
+
+  lines.push('', `${heading}:`, ...items.map((item) => `- ${item}`));
+}

--- a/tests/openclaw-config.test.ts
+++ b/tests/openclaw-config.test.ts
@@ -199,6 +199,7 @@ test('export/import/validate uses fixture config and persists agent into target 
     'validate',
     '--target-workspace', importWorkspace,
     '--agent-id', 'supercoder-imported',
+    '--json',
   ]);
   const report = JSON.parse(stdout);
   assert.equal(report.failed.length, 0);

--- a/tests/package-roundtrip.test.ts
+++ b/tests/package-roundtrip.test.ts
@@ -42,13 +42,55 @@ test('package reader opens a valid exported package and verifies checksums', asy
   assert.equal(pkg.checksums['config/agent.json'].length, 64);
 });
 
+test('export command defaults to human-readable output and supports --json', async () => {
+  await rm(outputRoot, { recursive: true, force: true });
+
+  const human = await runCli(['export', '--workspace', fixture, '--out', outputRoot]);
+  assert.match(human.stdout, /Export complete/);
+  assert.match(human.stdout, /Package:/);
+  assert.match(human.stdout, /Manifest:/);
+  assert.match(human.stdout, /Files:/);
+  assert.equal(human.stdout.includes('"status"'), false);
+
+  await rm(outputRoot, { recursive: true, force: true });
+
+  const json = await runCli(['export', '--workspace', fixture, '--out', outputRoot, '--json']);
+  const report = JSON.parse(json.stdout);
+  assert.equal(report.status, 'ok');
+  assert.ok(report.packageRoot);
+  assert.ok(report.manifestPath);
+  assert.equal(typeof report.fileCount, 'number');
+});
+
+test('import success defaults to human-readable output and supports --json', async () => {
+  await rm(outputRoot, { recursive: true, force: true });
+  await rm(path.dirname(targetRoot), { recursive: true, force: true });
+  await runCli(['export', '--workspace', fixture, '--out', outputRoot]);
+
+  const human = await runCli(['import', outputRoot, '--target-workspace', targetRoot, '--agent-id', 'supercoder-copy']);
+  assert.match(human.stdout, /Import complete/);
+  assert.match(human.stdout, /Workspace:/);
+  assert.match(human.stdout, /Agent id: supercoder-copy/);
+  assert.match(human.stdout, /Imported files:/);
+  assert.equal(human.stdout.includes('"status"'), false);
+
+  await rm(path.dirname(targetRoot), { recursive: true, force: true });
+
+  const json = await runCli(['import', outputRoot, '--target-workspace', targetRoot, '--agent-id', 'supercoder-copy', '--json']);
+  const report = JSON.parse(json.stdout);
+  assert.equal(report.status, 'ok');
+  assert.equal(report.agentId, 'supercoder-copy');
+  assert.ok(Array.isArray(report.importedFiles));
+  assert.ok(Array.isArray(report.nextSteps));
+});
+
 test('roundtrip export -> import -> validate succeeds with expected warnings', async () => {
   await rm(outputRoot, { recursive: true, force: true });
   await rm(path.dirname(targetRoot), { recursive: true, force: true });
 
   await runCli(['export', '--workspace', fixture, '--out', outputRoot]);
   await runCli(['import', outputRoot, '--target-workspace', targetRoot, '--agent-id', 'supercoder-copy']);
-  const { stdout } = await runCli(['validate', '--target-workspace', targetRoot, '--agent-id', 'supercoder-copy']);
+  const { stdout } = await runCli(['validate', '--target-workspace', targetRoot, '--agent-id', 'supercoder-copy', '--json']);
 
   const report = JSON.parse(stdout);
   assert.equal(report.failed.length, 0);

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -17,10 +17,26 @@ async function exportAndImport() {
   await runCli(['import', packageRoot, '--target-workspace', targetRoot, '--agent-id', 'supercoder-copy']);
 }
 
+test('validate command defaults to human-readable output and supports --json', async () => {
+  await exportAndImport();
+
+  const human = await runCli(['validate', '--target-workspace', targetRoot, '--agent-id', 'supercoder-copy']);
+  assert.match(human.stdout, /Validation: passed/);
+  assert.match(human.stdout, /Passed:/);
+  assert.match(human.stdout, /Warnings:/);
+  assert.match(human.stdout, /Next steps:/);
+  assert.equal(human.stdout.includes('"passed"'), false);
+
+  const json = await runCli(['validate', '--target-workspace', targetRoot, '--agent-id', 'supercoder-copy', '--json']);
+  const report = JSON.parse(json.stdout);
+  assert.ok(Array.isArray(report.passed));
+  assert.ok(Array.isArray(report.failed));
+});
+
 test('validate command reports passed warnings failed and nextSteps', async () => {
   await exportAndImport();
 
-  const { stdout } = await runCli(['validate', '--target-workspace', targetRoot, '--agent-id', 'supercoder-copy']);
+  const { stdout } = await runCli(['validate', '--target-workspace', targetRoot, '--agent-id', 'supercoder-copy', '--json']);
   const report = JSON.parse(stdout);
 
   assert.equal(Array.isArray(report.passed), true);
@@ -60,6 +76,7 @@ test('validate reports target config consistency when config path is provided', 
     '--target-workspace', targetRoot,
     '--agent-id', 'supercoder-copy',
     '--config', configPath,
+    '--json',
   ]);
   const report = JSON.parse(stdout);
 
@@ -82,6 +99,7 @@ test('validate reports target config consistency when config path is provided', 
     '--target-workspace', targetRoot,
     '--agent-id', 'supercoder-copy',
     '--config', configPath,
+    '--json',
   ]);
   const mismatchReport = JSON.parse(mismatch.stdout);
   assert.ok(mismatchReport.failed.some((entry: string) => entry.includes('workspace mismatch')));
@@ -91,7 +109,7 @@ test('validate reports missing required workspace files as failures', async () =
   await exportAndImport();
   await rm(path.join(targetRoot, 'AGENTS.md'), { force: true });
 
-  const { stdout } = await runCli(['validate', '--target-workspace', targetRoot, '--agent-id', 'supercoder-copy']);
+  const { stdout } = await runCli(['validate', '--target-workspace', targetRoot, '--agent-id', 'supercoder-copy', '--json']);
   const report = JSON.parse(stdout);
 
   assert.ok(report.failed.some((failure: string) => failure.includes('AGENTS.md')));


### PR DESCRIPTION
## Summary

- All four CLI commands (`inspect`, `export`, `import`, `validate`) now default to **human-readable text output** and support `--json` for machine-readable JSON
- Extracts shared `pushSection` helper to `src/utils/output.ts` for consistent section rendering across commands
- `import --json` now covers both success and blocked paths (previously only blocked)

## Changes

| File | What changed |
|---|---|
| `src/utils/output.ts` | New shared formatter utility |
| `src/commands/export.ts` | Human-readable default + `--json` flag |
| `src/commands/import.ts` | Human-readable success output + `--json` extended to success path |
| `src/commands/validate.ts` | Human-readable default + `--json` flag |
| `tests/package-roundtrip.test.ts` | 2 new tests for export/import output modes |
| `tests/validate.test.ts` | 1 new test for validate output modes |
| `tests/openclaw-config.test.ts` | Existing validate call updated with `--json` |

## Test plan

- [x] `npm run build` passes
- [x] `npm test` — 32/32 tests pass (29 existing + 3 new)
- [x] Each new command tested for both human-readable default and `--json` output
- [x] `inspect` behavior unchanged (no modifications)
- [x] Import blocked path behavior unchanged (existing tests still pass)

Closes #13

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 在 export、import 和 validate 命令中添加 --json 标志，支持机器可读的JSON格式输出

* **测试**
  * 扩展测试覆盖范围，验证JSON输出和人类可读格式的输出路径

<!-- end of auto-generated comment: release notes by coderabbit.ai -->