### PR TITLE
feat: add Biome as unified linter/formatter toolchain

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.7/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "includes": ["src/**/*.ts", "tests/**/*.ts"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "complexity": {
+        "noForEach": "off"
+      },
+      "style": {
+        "noNonNullAssertion": "warn",
+        "useNodejsImportProtocol": "error"
+      }
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "trailingCommas": "all"
+    }
+  },
+  "assist": {
+    "enabled": true,
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,12 +17,176 @@
         "clawpacker": "dist/cli.js"
       },
       "devDependencies": {
+        "@biomejs/biome": "^2.4.7",
         "@types/node": "^22.13.10",
         "tsx": "^4.19.3",
         "typescript": "^5.8.2"
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.7.tgz",
+      "integrity": "sha512-vXrgcmNGZ4lpdwZSpMf1hWw1aWS6B+SyeSYKTLrNsiUsAdSRN0J4d/7mF3ogJFbIwFFSOL3wT92Zzxia/d5/ng==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.4.7",
+        "@biomejs/cli-darwin-x64": "2.4.7",
+        "@biomejs/cli-linux-arm64": "2.4.7",
+        "@biomejs/cli-linux-arm64-musl": "2.4.7",
+        "@biomejs/cli-linux-x64": "2.4.7",
+        "@biomejs/cli-linux-x64-musl": "2.4.7",
+        "@biomejs/cli-win32-arm64": "2.4.7",
+        "@biomejs/cli-win32-x64": "2.4.7"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.7.tgz",
+      "integrity": "sha512-Oo0cF5mHzmvDmTXw8XSjhCia8K6YrZnk7aCS54+/HxyMdZMruMO3nfpDsrlar/EQWe41r1qrwKiCa2QDYHDzWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.7.tgz",
+      "integrity": "sha512-I+cOG3sd/7HdFtvDSnF9QQPrWguUH7zrkIMMykM3PtfWU9soTcS2yRb9Myq6MHmzbeCT08D1UmY+BaiMl5CcoQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.7.tgz",
+      "integrity": "sha512-om6FugwmibzfP/6ALj5WRDVSND4H2G9X0nkI1HZpp2ySf9lW2j0X68oQSaHEnls6666oy4KDsc5RFjT4m0kV0w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.7.tgz",
+      "integrity": "sha512-I2NvM9KPb09jWml93O2/5WMfNR7Lee5Latag1JThDRMURVhPX74p9UDnyTw3Ae6cE1DgXfw7sqQgX7rkvpc0vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.7.tgz",
+      "integrity": "sha512-bV8/uo2Tj+gumnk4sUdkerWyCPRabaZdv88IpbmDWARQQoA/Q0YaqPz1a+LSEDIL7OfrnPi9Hq1Llz4ZIGyIQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.7.tgz",
+      "integrity": "sha512-00kx4YrBMU8374zd2wHuRV5wseh0rom5HqRND+vDldJPrWwQw+mzd/d8byI9hPx926CG+vWzq6AeiT7Yi5y59g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.7.tgz",
+      "integrity": "sha512-hOUHBMlFCvDhu3WCq6vaBoG0dp0LkWxSEnEEsxxXvOa9TfT6ZBnbh72A/xBM7CBYB7WgwqboetzFEVDnMxelyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.7.tgz",
+      "integrity": "sha512-qEpGjSkPC3qX4ycbMUthXvi9CkRq7kZpkqMY1OyhmYlYLnANnooDQ7hDerM8+0NJ+DZKVnsIc07h30XOpt7LtQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "tsx src/cli.ts",
+    "lint": "biome check .",
+    "lint:fix": "biome check --write .",
     "prepublishOnly": "npm run build && npm test",
     "test": "tsx --test tests/*.test.ts"
   },
@@ -25,6 +27,7 @@
     "tar": "^7.5.11"
   },
   "devDependencies": {
+    "@biomejs/biome": "^2.4.7",
     "@types/node": "^22.13.10",
     "tsx": "^4.19.3",
     "typescript": "^5.8.2"

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -26,7 +26,8 @@ export async function runExport(options: ExportOptions): Promise<void> {
     configPath: options.config,
     agentId: options.agentId,
   });
-  const packageName = options.name ?? path.basename(options.out).replace(/\.ocpkg(\.tar\.gz)?$/, '');
+  const packageName =
+    options.name ?? path.basename(options.out).replace(/\.ocpkg(\.tar\.gz)?$/, '');
 
   const writeParams = {
     outputPath: path.resolve(options.out),
@@ -52,12 +53,14 @@ export async function runExport(options: ExportOptions): Promise<void> {
     return;
   }
 
-  console.log([
-    'Export complete',
-    `  Package: ${report.packageRoot}`,
-    `  Manifest: ${report.manifestPath}`,
-    `  Files: ${report.fileCount}`,
-  ].join('\n'));
+  console.log(
+    [
+      'Export complete',
+      `  Package: ${report.packageRoot}`,
+      `  Manifest: ${report.manifestPath}`,
+      `  Files: ${report.fileCount}`,
+    ].join('\n'),
+  );
 }
 
 export function registerExportCommand(command: Command): void {

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -1,11 +1,11 @@
 import path from 'node:path';
 import type { Command } from 'commander';
 import { executeImport } from '../core/import-exec';
-import { discoverOpenClawConfig } from '../core/openclaw-config';
 import { planImport } from '../core/import-plan';
+import { discoverOpenClawConfig } from '../core/openclaw-config';
 import { cleanupTempDir, readPackage } from '../core/package-read';
 import type { ImportPlan } from '../core/types';
-import { renderableCliErrorBrand, type RenderableCliError } from '../renderable-cli-error';
+import { type RenderableCliError, renderableCliErrorBrand } from '../renderable-cli-error';
 import { pushSection } from '../utils/output';
 
 interface ImportOptions {
@@ -16,10 +16,8 @@ interface ImportOptions {
   json?: boolean;
 }
 
-interface BlockedImportReport extends Pick<
-  ImportPlan,
-  'failed' | 'requiredInputs' | 'warnings' | 'nextSteps' | 'writePlan'
-> {
+interface BlockedImportReport
+  extends Pick<ImportPlan, 'failed' | 'requiredInputs' | 'warnings' | 'nextSteps' | 'writePlan'> {
   status: 'blocked';
 }
 
@@ -35,9 +33,7 @@ class ImportBlockedError extends Error implements RenderableCliError {
   }
 
   render(): string {
-    return this.asJson
-      ? JSON.stringify(this.report, null, 2)
-      : this.message;
+    return this.asJson ? JSON.stringify(this.report, null, 2) : this.message;
   }
 }
 
@@ -97,12 +93,18 @@ export async function runImport(packagePath: string, options: ImportOptions): Pr
 
   try {
     const pkg = await readPackage(path.resolve(packagePath), {
-      onTempDir(dir) { tempDir = dir; },
+      onTempDir(dir) {
+        tempDir = dir;
+      },
     });
 
     const configPath = options.config
       ? path.resolve(options.config)
-      : (await discoverOpenClawConfig({ cwd: path.resolve(options.targetWorkspace) }).catch(() => undefined))?.configPath;
+      : (
+          await discoverOpenClawConfig({ cwd: path.resolve(options.targetWorkspace) }).catch(
+            () => undefined,
+          )
+        )?.configPath;
 
     const plan = await planImport({
       pkg,
@@ -113,14 +115,17 @@ export async function runImport(packagePath: string, options: ImportOptions): Pr
     });
 
     if (!plan.canProceed) {
-      throw new ImportBlockedError({
-        status: 'blocked',
-        failed: plan.failed,
-        requiredInputs: plan.requiredInputs,
-        warnings: plan.warnings,
-        nextSteps: plan.nextSteps,
-        writePlan: plan.writePlan,
-      }, options.json === true);
+      throw new ImportBlockedError(
+        {
+          status: 'blocked',
+          failed: plan.failed,
+          requiredInputs: plan.requiredInputs,
+          warnings: plan.warnings,
+          nextSteps: plan.nextSteps,
+          writePlan: plan.writePlan,
+        },
+        options.json === true,
+      );
     }
 
     const result = await executeImport({ pkg, plan });

--- a/src/commands/inspect.ts
+++ b/src/commands/inspect.ts
@@ -64,7 +64,9 @@ export async function runInspect(options: InspectOptions): Promise<void> {
     `  workspace basename: ${report.portableConfig.agent.workspace.suggestedBasename}`,
     `  identity name: ${report.portableConfig.agent.identity.name}`,
     `  default model: ${report.portableConfig.agent.model?.default ?? 'not set'}`,
-    `  portable fields: ${Object.entries(report.portableConfig.fieldClassification).map(([key, value]) => `${key}=${value}`).join(', ')}`,
+    `  portable fields: ${Object.entries(report.portableConfig.fieldClassification)
+      .map(([key, value]) => `${key}=${value}`)
+      .join(', ')}`,
     `Skills (workspace): ${skills.workspaceSkills.join(', ') || 'none'}`,
     `Skills (referenced): ${skills.referencedSkills.join(', ') || 'none'}`,
     `Skill notes: ${skills.notes.join(' | ') || 'none'}`,

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -26,9 +26,7 @@ export async function runValidate(options: ValidateOptions): Promise<void> {
     return;
   }
 
-  const lines = [
-    `Validation: ${report.failed.length === 0 ? 'passed' : 'FAILED'}`,
-  ];
+  const lines = [`Validation: ${report.failed.length === 0 ? 'passed' : 'FAILED'}`];
 
   pushSection(lines, 'Passed', report.passed);
   pushSection(lines, 'Warnings', report.warnings);

--- a/src/core/agent-extract.ts
+++ b/src/core/agent-extract.ts
@@ -1,8 +1,11 @@
 import path from 'node:path';
-import type { AgentDefinition } from './types';
 import { extractPortableAgentDefinition, loadOpenClawConfig } from './openclaw-config';
+import type { AgentDefinition } from './types';
 
-export async function extractAgentDefinition(workspacePath: string, options: { configPath?: string; agentId?: string } = {}): Promise<AgentDefinition> {
+export async function extractAgentDefinition(
+  workspacePath: string,
+  options: { configPath?: string; agentId?: string } = {},
+): Promise<AgentDefinition> {
   try {
     const loaded = await loadOpenClawConfig({ configPath: options.configPath, cwd: workspacePath });
     return extractPortableAgentDefinition({

--- a/src/core/import-exec.ts
+++ b/src/core/import-exec.ts
@@ -1,12 +1,17 @@
 import { cp, mkdir, rm } from 'node:fs/promises';
 import path from 'node:path';
-import type { ImportPlan, ImportResult, ReadPackageResult } from './types';
 import { writeJsonFile } from '../utils/json';
 import { upsertPortableAgentDefinition } from './openclaw-config';
+import type { ImportPlan, ImportResult, ReadPackageResult } from './types';
 
-export async function executeImport(params: { pkg: ReadPackageResult; plan: ImportPlan }): Promise<ImportResult> {
+export async function executeImport(params: {
+  pkg: ReadPackageResult;
+  plan: ImportPlan;
+}): Promise<ImportResult> {
   if (!params.plan.canProceed) {
-    throw new Error(`Import plan cannot proceed: ${params.plan.failed.concat(params.plan.requiredInputs.map((item) => item.key)).join(', ')}`);
+    throw new Error(
+      `Import plan cannot proceed: ${params.plan.failed.concat(params.plan.requiredInputs.map((item) => item.key)).join(', ')}`,
+    );
   }
 
   if (params.plan.writePlan.overwriteExisting) {
@@ -21,7 +26,10 @@ export async function executeImport(params: { pkg: ReadPackageResult; plan: Impo
   }
 
   await mkdir(params.plan.writePlan.metadataDirectory, { recursive: true });
-  const agentRecordPath = path.join(params.plan.writePlan.metadataDirectory, 'agent-definition.json');
+  const agentRecordPath = path.join(
+    params.plan.writePlan.metadataDirectory,
+    'agent-definition.json',
+  );
   const importRecordPath = path.join(params.plan.writePlan.metadataDirectory, 'import-result.json');
 
   const configFiles: string[] = [];

--- a/src/core/import-plan.ts
+++ b/src/core/import-plan.ts
@@ -1,7 +1,7 @@
 import { access } from 'node:fs/promises';
 import path from 'node:path';
-import type { ImportPlan, ReadPackageResult } from './types';
 import { loadOpenClawConfig } from './openclaw-config';
+import type { ImportPlan, ReadPackageResult } from './types';
 
 export async function planImport(params: {
   pkg: ReadPackageResult;
@@ -19,10 +19,16 @@ export async function planImport(params: {
   ];
 
   if (!params.targetWorkspacePath) {
-    requiredInputs.push({ key: 'targetWorkspacePath', reason: 'A target workspace path is required for import.' });
+    requiredInputs.push({
+      key: 'targetWorkspacePath',
+      reason: 'A target workspace path is required for import.',
+    });
   }
   if (!params.targetAgentId) {
-    requiredInputs.push({ key: 'agentId', reason: 'Choose a target agent id for the imported definition.' });
+    requiredInputs.push({
+      key: 'agentId',
+      reason: 'Choose a target agent id for the imported definition.',
+    });
   }
 
   const targetWorkspacePath = path.resolve(
@@ -33,27 +39,39 @@ export async function planImport(params: {
   const workspaceExists = await pathExists(targetWorkspacePath);
   if (workspaceExists && !params.force) {
     failed.push(`Target workspace already exists: ${targetWorkspacePath}`);
-    nextSteps.push('Choose a different --target-workspace path or re-run with --force to overwrite the existing workspace.');
+    nextSteps.push(
+      'Choose a different --target-workspace path or re-run with --force to overwrite the existing workspace.',
+    );
   } else if (workspaceExists) {
-    warnings.push(`Target workspace exists and will be overwritten because --force was provided: ${targetWorkspacePath}`);
+    warnings.push(
+      `Target workspace exists and will be overwritten because --force was provided: ${targetWorkspacePath}`,
+    );
   }
 
   let configAgentCollision = false;
   if (!params.targetConfigPath) {
-    warnings.push('OpenClaw config not found; agent definition will only be recorded in local import metadata.');
+    warnings.push(
+      'OpenClaw config not found; agent definition will only be recorded in local import metadata.',
+    );
   } else if (await pathExists(params.targetConfigPath)) {
     const { config } = await loadOpenClawConfig({ configPath: params.targetConfigPath });
     if (config.agents?.[targetAgentId]) {
       configAgentCollision = true;
       if (!params.force) {
         failed.push(`Target agent already exists in OpenClaw config: ${targetAgentId}`);
-        nextSteps.push('Choose a different --agent-id or re-run with --force to update the existing OpenClaw config entry.');
+        nextSteps.push(
+          'Choose a different --agent-id or re-run with --force to update the existing OpenClaw config entry.',
+        );
       } else {
-        warnings.push(`OpenClaw config already contains agent ${targetAgentId}; it will be overwritten because --force was provided.`);
+        warnings.push(
+          `OpenClaw config already contains agent ${targetAgentId}; it will be overwritten because --force was provided.`,
+        );
       }
     }
   } else {
-    warnings.push(`Target OpenClaw config does not exist yet and will be created during import: ${params.targetConfigPath}`);
+    warnings.push(
+      `Target OpenClaw config does not exist yet and will be created during import: ${params.targetConfigPath}`,
+    );
   }
 
   const metadataDirectory = path.join(targetWorkspacePath, '.openclaw-agent-package');

--- a/src/core/manifest.ts
+++ b/src/core/manifest.ts
@@ -1,6 +1,13 @@
 import path from 'node:path';
 import { EXPORT_MODE, PACKAGE_FORMAT_VERSION, PACKAGE_TYPE, SKILLS_MODE } from './constants';
-import type { AgentDefinition, ExportArtifacts, ExportReport, PackageManifest, SkillsManifest, WorkspaceScanResult } from './types';
+import type {
+  AgentDefinition,
+  ExportArtifacts,
+  ExportReport,
+  PackageManifest,
+  SkillsManifest,
+  WorkspaceScanResult,
+} from './types';
 
 export function buildManifest(params: {
   packageName: string;

--- a/src/core/openclaw-config.ts
+++ b/src/core/openclaw-config.ts
@@ -1,26 +1,30 @@
-import { access, mkdir } from 'node:fs/promises';
+import { access, mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
-import type { AgentDefinition } from './types';
-import { readFile, writeFile } from 'node:fs/promises';
 import stripJsonComments from 'strip-json-comments';
+import type { AgentDefinition } from './types';
 
 export interface MinimalOpenClawConfig {
-  agents?: Record<string, {
-    id?: string;
-    name?: string;
-    workspace?: string;
-    identity?: {
+  agents?: Record<
+    string,
+    {
+      id?: string;
       name?: string;
-    };
-    model?: {
-      default?: string;
-    };
-    [key: string]: unknown;
-  }>;
+      workspace?: string;
+      identity?: {
+        name?: string;
+      };
+      model?: {
+        default?: string;
+      };
+      [key: string]: unknown;
+    }
+  >;
   [key: string]: unknown;
 }
 
-export async function discoverOpenClawConfig(params: { configPath?: string; cwd?: string } = {}): Promise<{ configPath: string }> {
+export async function discoverOpenClawConfig(
+  params: { configPath?: string; cwd?: string } = {},
+): Promise<{ configPath: string }> {
   const candidates = params.configPath
     ? [path.resolve(params.configPath)]
     : [
@@ -40,7 +44,10 @@ export async function discoverOpenClawConfig(params: { configPath?: string; cwd?
   throw new Error(`OpenClaw config not found. Checked: ${candidates.join(', ')}`);
 }
 
-export async function loadOpenClawConfig(params: { configPath?: string; cwd?: string }): Promise<{ configPath: string; config: MinimalOpenClawConfig }> {
+export async function loadOpenClawConfig(params: {
+  configPath?: string;
+  cwd?: string;
+}): Promise<{ configPath: string; config: MinimalOpenClawConfig }> {
   const discovered = await discoverOpenClawConfig(params);
   const raw = await readFile(discovered.configPath, 'utf8');
   return {
@@ -57,14 +64,18 @@ export function extractPortableAgentDefinition(params: {
 }): AgentDefinition {
   const workspaceBasename = path.basename(params.workspacePath);
   const fallbackId = workspaceBasename.replace(/^workspace-/, '');
-  const selectedAgentId = params.agentId ?? findAgentIdByWorkspace(params.config, params.workspacePath) ?? fallbackId;
+  const selectedAgentId =
+    params.agentId ?? findAgentIdByWorkspace(params.config, params.workspacePath) ?? fallbackId;
   const sourceAgent = params.config.agents?.[selectedAgentId];
 
   if (!sourceAgent) {
     throw new Error(`Agent not found in OpenClaw config: ${selectedAgentId}`);
   }
 
-  const suggestedName = sourceAgent.name ?? sourceAgent.identity?.name ?? toTitleCase(selectedAgentId.replace(/-/g, ' '));
+  const suggestedName =
+    sourceAgent.name ??
+    sourceAgent.identity?.name ??
+    toTitleCase(selectedAgentId.replace(/-/g, ' '));
   const identityName = sourceAgent.identity?.name ?? suggestedName;
 
   return {
@@ -141,7 +152,10 @@ function parseJsonc(value: string): unknown {
   return JSON.parse(withoutComments);
 }
 
-function findAgentIdByWorkspace(config: MinimalOpenClawConfig, workspacePath: string): string | undefined {
+function findAgentIdByWorkspace(
+  config: MinimalOpenClawConfig,
+  workspacePath: string,
+): string | undefined {
   for (const [agentId, agent] of Object.entries(config.agents ?? {})) {
     if (agent.workspace && path.basename(agent.workspace) === path.basename(workspacePath)) {
       return agentId;

--- a/src/core/package-read.ts
+++ b/src/core/package-read.ts
@@ -1,10 +1,17 @@
 import { access, readdir, stat } from 'node:fs/promises';
 import path from 'node:path';
-import { cleanupTempDir, extractArchive, isArchivePath } from './archive';
-import { PACKAGE_FORMAT_VERSION, PACKAGE_TYPE } from './constants';
-import { checksumFile } from './checksums';
-import type { ExportReport, ImportHints, PackageManifest, ReadPackageResult, SkillsManifest, AgentDefinition } from './types';
 import { readJsonFile } from '../utils/json';
+import { extractArchive, isArchivePath } from './archive';
+import { checksumFile } from './checksums';
+import { PACKAGE_FORMAT_VERSION, PACKAGE_TYPE } from './constants';
+import type {
+  AgentDefinition,
+  ExportReport,
+  ImportHints,
+  PackageManifest,
+  ReadPackageResult,
+  SkillsManifest,
+} from './types';
 
 export interface ReadPackageOptions {
   onTempDir?: (tempDir: string) => void;
@@ -75,11 +82,21 @@ export async function readPackageDirectory(packageRoot: string): Promise<ReadPac
     throw new Error(`Unsupported format version: ${manifest.formatVersion}`);
   }
 
-  const agentDefinition = await readJsonFile<AgentDefinition>(path.join(resolvedRoot, 'config', 'agent.json'));
-  const skillsManifest = await readJsonFile<SkillsManifest>(path.join(resolvedRoot, 'config', 'skills-manifest.json'));
-  const importHints = await readJsonFile<ImportHints>(path.join(resolvedRoot, 'config', 'import-hints.json'));
-  const checksums = await readJsonFile<Record<string, string>>(path.join(resolvedRoot, 'meta', 'checksums.json'));
-  const exportReport = await readJsonFile<ExportReport>(path.join(resolvedRoot, 'meta', 'export-report.json'));
+  const agentDefinition = await readJsonFile<AgentDefinition>(
+    path.join(resolvedRoot, 'config', 'agent.json'),
+  );
+  const skillsManifest = await readJsonFile<SkillsManifest>(
+    path.join(resolvedRoot, 'config', 'skills-manifest.json'),
+  );
+  const importHints = await readJsonFile<ImportHints>(
+    path.join(resolvedRoot, 'config', 'import-hints.json'),
+  );
+  const checksums = await readJsonFile<Record<string, string>>(
+    path.join(resolvedRoot, 'meta', 'checksums.json'),
+  );
+  const exportReport = await readJsonFile<ExportReport>(
+    path.join(resolvedRoot, 'meta', 'export-report.json'),
+  );
 
   for (const [relativePath, expectedChecksum] of Object.entries(checksums)) {
     const actualChecksum = await checksumFile(path.join(resolvedRoot, relativePath));

--- a/src/core/package-write.ts
+++ b/src/core/package-write.ts
@@ -3,7 +3,13 @@ import path from 'node:path';
 import { createArchive, deriveArchivePath } from './archive';
 import { checksumFile, checksumText } from './checksums';
 import { buildExportArtifacts } from './manifest';
-import type { AgentDefinition, ExportPackageResult, ImportHints, SkillsManifest, WorkspaceScanResult } from './types';
+import type {
+  AgentDefinition,
+  ExportPackageResult,
+  ImportHints,
+  SkillsManifest,
+  WorkspaceScanResult,
+} from './types';
 
 export async function writePackageArchive(params: {
   outputPath: string;
@@ -54,7 +60,9 @@ export async function writePackageDirectory(params: {
   }
 
   const importHints: ImportHints = {
-    requiredInputs: [{ key: 'agentId', reason: 'Target instance may already contain the source agent id.' }],
+    requiredInputs: [
+      { key: 'agentId', reason: 'Target instance may already contain the source agent id.' },
+    ],
     warnings: [
       'Channel bindings are not included in v1 packages.',
       'Skills are manifest-only and may require manual installation.',
@@ -64,9 +72,17 @@ export async function writePackageDirectory(params: {
   const skillsJson = JSON.stringify(params.skills, null, 2);
   const agentJson = JSON.stringify(params.agentDefinition, null, 2);
   const importHintsJson = JSON.stringify(importHints, null, 2);
-  await writeFile(path.join(params.outputPath, 'config', 'skills-manifest.json'), `${skillsJson}\n`, 'utf8');
+  await writeFile(
+    path.join(params.outputPath, 'config', 'skills-manifest.json'),
+    `${skillsJson}\n`,
+    'utf8',
+  );
   await writeFile(path.join(params.outputPath, 'config', 'agent.json'), `${agentJson}\n`, 'utf8');
-  await writeFile(path.join(params.outputPath, 'config', 'import-hints.json'), `${importHintsJson}\n`, 'utf8');
+  await writeFile(
+    path.join(params.outputPath, 'config', 'import-hints.json'),
+    `${importHintsJson}\n`,
+    'utf8',
+  );
   checksums['config/skills-manifest.json'] = checksumText(`${skillsJson}\n`);
   checksums['config/agent.json'] = checksumText(`${agentJson}\n`);
   checksums['config/import-hints.json'] = checksumText(`${importHintsJson}\n`);
@@ -86,8 +102,16 @@ export async function writePackageDirectory(params: {
   const reportJson = JSON.stringify(artifacts.exportReport, null, 2);
 
   await writeFile(path.join(params.outputPath, 'manifest.json'), `${manifestJson}\n`, 'utf8');
-  await writeFile(path.join(params.outputPath, 'meta', 'checksums.json'), `${checksumsJson}\n`, 'utf8');
-  await writeFile(path.join(params.outputPath, 'meta', 'export-report.json'), `${reportJson}\n`, 'utf8');
+  await writeFile(
+    path.join(params.outputPath, 'meta', 'checksums.json'),
+    `${checksumsJson}\n`,
+    'utf8',
+  );
+  await writeFile(
+    path.join(params.outputPath, 'meta', 'export-report.json'),
+    `${reportJson}\n`,
+    'utf8',
+  );
 
   return {
     packageRoot: params.outputPath,

--- a/src/core/validate.ts
+++ b/src/core/validate.ts
@@ -1,9 +1,9 @@
 import { access } from 'node:fs/promises';
 import path from 'node:path';
-import { REQUIRED_WORKSPACE_FILES } from './constants';
-import type { ValidationReport } from './types';
 import { readJsonFile } from '../utils/json';
+import { REQUIRED_WORKSPACE_FILES } from './constants';
 import { loadOpenClawConfig } from './openclaw-config';
+import type { ValidationReport } from './types';
 
 export async function validateImportedWorkspace(params: {
   targetWorkspacePath: string;
@@ -40,30 +40,46 @@ export async function validateImportedWorkspace(params: {
     if (!params.agentId || agentRecord.agentId === params.agentId) {
       report.passed.push(`Portable agent definition record present: ${agentRecordPath}`);
     } else {
-      report.failed.push(`Imported agent record id mismatch: expected ${params.agentId}, got ${agentRecord.agentId ?? 'unknown'}`);
+      report.failed.push(
+        `Imported agent record id mismatch: expected ${params.agentId}, got ${agentRecord.agentId ?? 'unknown'}`,
+      );
     }
   } else {
     report.failed.push(`Missing imported agent definition record: ${agentRecordPath}`);
   }
 
   if (params.targetConfigPath) {
-    const { configPath, config } = await loadOpenClawConfig({ configPath: params.targetConfigPath });
+    const { configPath, config } = await loadOpenClawConfig({
+      configPath: params.targetConfigPath,
+    });
     if (!params.agentId) {
-      report.warnings.push(`OpenClaw config consistency check skipped for ${configPath} because --agent-id was not provided.`);
+      report.warnings.push(
+        `OpenClaw config consistency check skipped for ${configPath} because --agent-id was not provided.`,
+      );
     } else {
       const configAgent = config.agents?.[params.agentId];
       if (!configAgent) {
         report.failed.push(`OpenClaw config agent missing: ${params.agentId} (${configPath})`);
-        report.nextSteps.push('Re-run import with --config or add the target agent entry manually to the OpenClaw config.');
+        report.nextSteps.push(
+          'Re-run import with --config or add the target agent entry manually to the OpenClaw config.',
+        );
       } else {
         report.passed.push(`OpenClaw config agent present: ${params.agentId} (${configPath})`);
-        const resolvedConfigWorkspace = configAgent.workspace ? path.resolve(configAgent.workspace) : undefined;
+        const resolvedConfigWorkspace = configAgent.workspace
+          ? path.resolve(configAgent.workspace)
+          : undefined;
         if (!resolvedConfigWorkspace) {
-          report.failed.push(`OpenClaw config agent workspace missing: ${params.agentId} (${configPath})`);
+          report.failed.push(
+            `OpenClaw config agent workspace missing: ${params.agentId} (${configPath})`,
+          );
         } else if (resolvedConfigWorkspace === targetWorkspacePath) {
-          report.passed.push(`OpenClaw config workspace matches imported workspace: ${resolvedConfigWorkspace}`);
+          report.passed.push(
+            `OpenClaw config workspace matches imported workspace: ${resolvedConfigWorkspace}`,
+          );
         } else {
-          report.failed.push(`OpenClaw config workspace mismatch for ${params.agentId}: expected ${targetWorkspacePath}, got ${resolvedConfigWorkspace}`);
+          report.failed.push(
+            `OpenClaw config workspace mismatch for ${params.agentId}: expected ${targetWorkspacePath}, got ${resolvedConfigWorkspace}`,
+          );
         }
       }
     }
@@ -71,7 +87,9 @@ export async function validateImportedWorkspace(params: {
 
   report.warnings.push('Skills are manifest-only and may require manual installation.');
   report.nextSteps.push('Channel bindings must be configured manually on the target instance.');
-  report.nextSteps.push('Review imported USER.md, TOOLS.md, and MEMORY.md for target-specific adjustments.');
+  report.nextSteps.push(
+    'Review imported USER.md, TOOLS.md, and MEMORY.md for target-specific adjustments.',
+  );
 
   return report;
 }

--- a/src/core/workspace-scan.ts
+++ b/src/core/workspace-scan.ts
@@ -17,7 +17,9 @@ export async function scanWorkspace(workspacePath: string): Promise<WorkspaceSca
       includedFiles.push({
         relativePath: file,
         absolutePath,
-        required: !OPTIONAL_WORKSPACE_FILES.includes(file as (typeof OPTIONAL_WORKSPACE_FILES)[number]),
+        required: !OPTIONAL_WORKSPACE_FILES.includes(
+          file as (typeof OPTIONAL_WORKSPACE_FILES)[number],
+        ),
       });
     } catch {
       if (OPTIONAL_WORKSPACE_FILES.includes(file as (typeof OPTIONAL_WORKSPACE_FILES)[number])) {
@@ -28,7 +30,9 @@ export async function scanWorkspace(workspacePath: string): Promise<WorkspaceSca
 
   for (const entry of entries) {
     if (entry.name === 'memory' && entry.isDirectory()) {
-      const memoryEntries = await readdir(path.join(workspacePath, 'memory'), { withFileTypes: true });
+      const memoryEntries = await readdir(path.join(workspacePath, 'memory'), {
+        withFileTypes: true,
+      });
       for (const memoryEntry of memoryEntries) {
         if (memoryEntry.isFile() && memoryEntry.name.endsWith('.md')) {
           excludedFiles.push({

--- a/src/renderable-cli-error.ts
+++ b/src/renderable-cli-error.ts
@@ -6,10 +6,12 @@ export interface RenderableCliError {
 }
 
 export function isRenderableCliError(error: unknown): error is RenderableCliError {
-  return typeof error === 'object'
-    && error !== null
-    && renderableCliErrorBrand in error
-    && error[renderableCliErrorBrand] === true
-    && 'render' in error
-    && typeof error.render === 'function';
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    renderableCliErrorBrand in error &&
+    error[renderableCliErrorBrand] === true &&
+    'render' in error &&
+    typeof error.render === 'function'
+  );
 }

--- a/tests/archive.test.ts
+++ b/tests/archive.test.ts
@@ -29,10 +29,21 @@ test('export --archive produces a .ocpkg.tar.gz file', async () => {
 test('export --archive output has correct .ocpkg.tar.gz suffix and CLI reports archive path', async () => {
   await rm(archiveOutput, { force: true });
 
-  const { stdout } = await runCli(['export', '--workspace', fixture, '--out', dirOutput, '--archive', '--json']);
+  const { stdout } = await runCli([
+    'export',
+    '--workspace',
+    fixture,
+    '--out',
+    dirOutput,
+    '--archive',
+    '--json',
+  ]);
   const result = JSON.parse(stdout);
 
-  assert.ok(result.packageRoot.endsWith('.ocpkg.tar.gz'), 'packageRoot should end with .ocpkg.tar.gz');
+  assert.ok(
+    result.packageRoot.endsWith('.ocpkg.tar.gz'),
+    'packageRoot should end with .ocpkg.tar.gz',
+  );
   assert.equal(result.status, 'ok');
   assert.ok(result.fileCount > 0);
 });
@@ -43,7 +54,9 @@ test('readPackage detects and extracts .tar.gz archive', async () => {
 
   let capturedTempDir: string | undefined;
   const pkg = await readPackage(archiveOutput, {
-    onTempDir(dir) { capturedTempDir = dir; },
+    onTempDir(dir) {
+      capturedTempDir = dir;
+    },
   });
 
   assert.ok(capturedTempDir, 'onTempDir callback should be called for archive input');
@@ -60,7 +73,9 @@ test('readPackage reads a directory without onTempDir callback', async () => {
 
   let tempDirCalled = false;
   const pkg = await readPackage(dirOutput, {
-    onTempDir() { tempDirCalled = true; },
+    onTempDir() {
+      tempDirCalled = true;
+    },
   });
 
   assert.equal(tempDirCalled, false, 'onTempDir should not be called for directory input');
@@ -74,15 +89,20 @@ test('archive roundtrip: export --archive -> import -> validate succeeds', async
 
   await runCli(['export', '--workspace', fixture, '--out', dirOutput, '--archive']);
   await runCli([
-    'import', archiveOutput,
-    '--target-workspace', archiveImportTarget,
-    '--agent-id', 'archive-test-agent',
+    'import',
+    archiveOutput,
+    '--target-workspace',
+    archiveImportTarget,
+    '--agent-id',
+    'archive-test-agent',
   ]);
 
   const { stdout } = await runCli([
     'validate',
-    '--target-workspace', archiveImportTarget,
-    '--agent-id', 'archive-test-agent',
+    '--target-workspace',
+    archiveImportTarget,
+    '--agent-id',
+    'archive-test-agent',
     '--json',
   ]);
 
@@ -121,9 +141,12 @@ test('archive import via CLI succeeds end-to-end', async () => {
   await runCli(['export', '--workspace', fixture, '--out', dirOutput, '--archive']);
 
   const { stdout: importStdout } = await runCli([
-    'import', archiveOutput,
-    '--target-workspace', archiveImportTarget,
-    '--agent-id', 'cleanup-test-agent',
+    'import',
+    archiveOutput,
+    '--target-workspace',
+    archiveImportTarget,
+    '--agent-id',
+    'cleanup-test-agent',
     '--json',
   ]);
 

--- a/tests/helpers/run-cli.ts
+++ b/tests/helpers/run-cli.ts
@@ -12,5 +12,9 @@ export const runCliExecOptions = {
 };
 
 export async function runCli(args: string[]) {
-  return execFileAsync(process.execPath, ['--import', 'tsx', 'src/cli.ts', ...args], runCliExecOptions);
+  return execFileAsync(
+    process.execPath,
+    ['--import', 'tsx', 'src/cli.ts', ...args],
+    runCliExecOptions,
+  );
 }

--- a/tests/import-command.test.ts
+++ b/tests/import-command.test.ts
@@ -25,10 +25,14 @@ async function prepareBlockedImportFixture() {
 
   await runCli([
     'export',
-    '--workspace', fixtureWorkspace,
-    '--config', fixtureConfig,
-    '--agent-id', 'supercoder',
-    '--out', blockedPackageRoot,
+    '--workspace',
+    fixtureWorkspace,
+    '--config',
+    fixtureConfig,
+    '--agent-id',
+    'supercoder',
+    '--out',
+    blockedPackageRoot,
   ]);
 }
 
@@ -48,8 +52,9 @@ async function runCliFailure(args: string[]) {
 test('runCliFailure rethrows assertion failures when the CLI succeeds', async () => {
   await assert.rejects(
     async () => runCliFailure(['--version']),
-    (error: unknown) => error instanceof assert.AssertionError
-      && /Expected CLI invocation to fail: --version/.test(error.message),
+    (error: unknown) =>
+      error instanceof assert.AssertionError &&
+      /Expected CLI invocation to fail: --version/.test(error.message),
   );
 });
 
@@ -59,7 +64,8 @@ test('blocked import prints clean human-readable output and exits non-zero', asy
   const error = await runCliFailure([
     'import',
     blockedPackageRoot,
-    '--target-workspace', blockedTargetRoot,
+    '--target-workspace',
+    blockedTargetRoot,
   ]);
 
   assert.equal(error.code, 1);
@@ -78,7 +84,8 @@ test('blocked import with --json prints clean JSON to stderr and exits non-zero'
   const error = await runCliFailure([
     'import',
     blockedPackageRoot,
-    '--target-workspace', blockedTargetRoot,
+    '--target-workspace',
+    blockedTargetRoot,
     '--json',
   ]);
 
@@ -90,8 +97,15 @@ test('blocked import with --json prints clean JSON to stderr and exits non-zero'
   const report = JSON.parse(error.stderr);
   assert.equal(report.status, 'blocked');
   assert.deepEqual(report.failed, []);
-  assert.deepEqual(report.requiredInputs.map((item: { key: string }) => item.key), ['agentId']);
+  assert.deepEqual(
+    report.requiredInputs.map((item: { key: string }) => item.key),
+    ['agentId'],
+  );
   assert.ok(report.warnings.some((warning: string) => warning.includes('Channel bindings')));
-  assert.ok(report.nextSteps.some((step: string) => step.includes('Review the imported identity and memory files')));
+  assert.ok(
+    report.nextSteps.some((step: string) =>
+      step.includes('Review the imported identity and memory files'),
+    ),
+  );
   assert.equal(report.writePlan.targetWorkspacePath, blockedTargetRoot);
 });

--- a/tests/import-plan.test.ts
+++ b/tests/import-plan.test.ts
@@ -35,7 +35,10 @@ test('planImport requires target inputs and warns about v1 manual follow-up', as
     targetWorkspacePath: targetRoot,
   });
 
-  assert.deepEqual(plan.requiredInputs.map((item) => item.key), ['agentId']);
+  assert.deepEqual(
+    plan.requiredInputs.map((item) => item.key),
+    ['agentId'],
+  );
   assert.equal(plan.canProceed, false);
   assert.ok(plan.warnings.some((warning) => warning.includes('Skills are manifest-only')));
   assert.ok(plan.nextSteps.some((step) => step.includes('Channel bindings')));
@@ -72,15 +75,22 @@ test('planImport preflights target config agent-id collisions and reports safer 
 
   await rm(configRoot, { recursive: true, force: true });
   await mkdir(configRoot, { recursive: true });
-  await writeFile(configPath, JSON.stringify({
-    agents: {
-      'supercoder-copy': {
-        id: 'supercoder-copy',
-        name: 'Existing Agent',
-        workspace: '/tmp/existing-workspace',
+  await writeFile(
+    configPath,
+    JSON.stringify(
+      {
+        agents: {
+          'supercoder-copy': {
+            id: 'supercoder-copy',
+            name: 'Existing Agent',
+            workspace: '/tmp/existing-workspace',
+          },
+        },
       },
-    },
-  }, null, 2));
+      null,
+      2,
+    ),
+  );
 
   const blocked = await planImport({
     pkg,
@@ -90,7 +100,9 @@ test('planImport preflights target config agent-id collisions and reports safer 
   });
 
   assert.equal(blocked.canProceed, false);
-  assert.ok(blocked.failed.some((failure) => failure.includes('already exists in OpenClaw config')));
+  assert.ok(
+    blocked.failed.some((failure) => failure.includes('already exists in OpenClaw config')),
+  );
   assert.ok(blocked.nextSteps.some((step) => step.includes('Choose a different --agent-id')));
   assert.ok(blocked.writePlan.metadataDirectory.endsWith('.openclaw-agent-package'));
   assert.ok(blocked.writePlan.workspaceFiles.some((file) => file.relativePath === 'AGENTS.md'));

--- a/tests/manifest.test.ts
+++ b/tests/manifest.test.ts
@@ -25,7 +25,14 @@ test('manifest builder emits required fields and manifest-only skills mode', asy
   assert.equal(manifest.packageType, 'openclaw-agent-template');
   assert.equal(manifest.includes.skills, 'manifest-only');
   assert.equal(manifest.includes.dailyMemory, false);
-  assert.deepEqual(manifest.includes.workspaceFiles, ['AGENTS.md', 'IDENTITY.md', 'MEMORY.md', 'SOUL.md', 'TOOLS.md', 'USER.md']);
+  assert.deepEqual(manifest.includes.workspaceFiles, [
+    'AGENTS.md',
+    'IDENTITY.md',
+    'MEMORY.md',
+    'SOUL.md',
+    'TOOLS.md',
+    'USER.md',
+  ]);
 });
 
 test('checksums and export report are deterministic and include exclusions', async () => {
@@ -43,5 +50,8 @@ test('checksums and export report are deterministic and include exclusions', asy
   });
 
   assert.equal(report.warnings[0], 'demo warning');
-  assert.deepEqual(report.excludedFiles.map((file) => file.relativePath), ['memory/2026-03-16.md']);
+  assert.deepEqual(
+    report.excludedFiles.map((file) => file.relativePath),
+    ['memory/2026-03-16.md'],
+  );
 });

--- a/tests/openclaw-config.test.ts
+++ b/tests/openclaw-config.test.ts
@@ -52,35 +52,43 @@ test('discover/load/extract reads minimal OpenClaw config fixture and returns po
 });
 
 test('loadOpenClawConfig preserves // inside JSON string values', async () => {
-  const configPath = await writeJsoncFixture('string-line-comment-token.jsonc', `{
+  const configPath = await writeJsoncFixture(
+    'string-line-comment-token.jsonc',
+    `{
   "agents": {
     "supercoder": {
       "name": "https://example.com//agents/supercoder"
     }
   }
 }
-`);
+`,
+  );
 
   const loaded = await loadOpenClawConfig({ configPath });
   assert.equal(loaded.config.agents?.supercoder?.name, 'https://example.com//agents/supercoder');
 });
 
 test('loadOpenClawConfig preserves /* */ inside JSON string values', async () => {
-  const configPath = await writeJsoncFixture('string-block-comment-token.jsonc', `{
+  const configPath = await writeJsoncFixture(
+    'string-block-comment-token.jsonc',
+    `{
   "agents": {
     "supercoder": {
       "name": "literal /* not a comment */ value"
     }
   }
 }
-`);
+`,
+  );
 
   const loaded = await loadOpenClawConfig({ configPath });
   assert.equal(loaded.config.agents?.supercoder?.name, 'literal /* not a comment */ value');
 });
 
 test('loadOpenClawConfig still accepts real JSONC line and block comments', async () => {
-  const configPath = await writeJsoncFixture('actual-comments.jsonc', `{
+  const configPath = await writeJsoncFixture(
+    'actual-comments.jsonc',
+    `{
   // agent catalog
   "agents": {
     /* exported agent */
@@ -89,7 +97,8 @@ test('loadOpenClawConfig still accepts real JSONC line and block comments', asyn
     }
   }
 }
-`);
+`,
+  );
 
   const loaded = await loadOpenClawConfig({ configPath });
   assert.equal(loaded.config.agents?.supercoder?.name, 'Supercoder');
@@ -138,9 +147,12 @@ test('inspect command defaults to human-readable output and supports --json', as
 
   const human = await runCli([
     'inspect',
-    '--workspace', fixtureWorkspace,
-    '--config', fixtureConfig,
-    '--agent-id', 'supercoder',
+    '--workspace',
+    fixtureWorkspace,
+    '--config',
+    fixtureConfig,
+    '--agent-id',
+    'supercoder',
   ]);
 
   assert.match(human.stdout, /Workspace:/);
@@ -151,16 +163,23 @@ test('inspect command defaults to human-readable output and supports --json', as
 
   const json = await runCli([
     'inspect',
-    '--workspace', fixtureWorkspace,
-    '--config', fixtureConfig,
-    '--agent-id', 'supercoder',
+    '--workspace',
+    fixtureWorkspace,
+    '--config',
+    fixtureConfig,
+    '--agent-id',
+    'supercoder',
     '--json',
   ]);
 
   const report = JSON.parse(json.stdout);
   assert.equal(report.workspacePath, fixtureWorkspace);
   assert.ok(report.includedFiles.includes('AGENTS.md'));
-  assert.ok(report.excludedFiles.some((entry: { relativePath: string }) => entry.relativePath === 'memory/2026-03-16.md'));
+  assert.ok(
+    report.excludedFiles.some(
+      (entry: { relativePath: string }) => entry.relativePath === 'memory/2026-03-16.md',
+    ),
+  );
   assert.equal(report.portableConfig.found, true);
   assert.equal(report.portableConfig.agent.suggestedId, 'supercoder');
   assert.deepEqual(report.skills.referencedSkills, ['brainstorming']);
@@ -174,22 +193,31 @@ test('export/import/validate uses fixture config and persists agent into target 
 
   await runCli([
     'export',
-    '--workspace', fixtureWorkspace,
-    '--config', fixtureConfig,
-    '--agent-id', 'supercoder',
-    '--out', exportOut,
+    '--workspace',
+    fixtureWorkspace,
+    '--config',
+    fixtureConfig,
+    '--agent-id',
+    'supercoder',
+    '--out',
+    exportOut,
   ]);
 
-  const agentJson = JSON.parse(await readFile(path.join(exportOut, 'config', 'agent.json'), 'utf8'));
+  const agentJson = JSON.parse(
+    await readFile(path.join(exportOut, 'config', 'agent.json'), 'utf8'),
+  );
   assert.equal(agentJson.agent.model.default, 'openai-codex/gpt-5.4');
   assert.ok(agentJson.notes.some((note: string) => note.includes('OpenClaw config')));
 
   await runCli([
     'import',
     exportOut,
-    '--target-workspace', importWorkspace,
-    '--agent-id', 'supercoder-imported',
-    '--config', importConfig,
+    '--target-workspace',
+    importWorkspace,
+    '--agent-id',
+    'supercoder-imported',
+    '--config',
+    importConfig,
   ]);
 
   const importedConfig = JSON.parse(await readFile(importConfig, 'utf8'));
@@ -197,8 +225,10 @@ test('export/import/validate uses fixture config and persists agent into target 
 
   const { stdout } = await runCli([
     'validate',
-    '--target-workspace', importWorkspace,
-    '--agent-id', 'supercoder-imported',
+    '--target-workspace',
+    importWorkspace,
+    '--agent-id',
+    'supercoder-imported',
     '--json',
   ]);
   const report = JSON.parse(stdout);

--- a/tests/package-roundtrip.test.ts
+++ b/tests/package-roundtrip.test.ts
@@ -23,7 +23,11 @@ test('export command writes package directory structure and excludes daily memor
     'workspace/AGENTS.md',
     'workspace/MEMORY.md',
   ]) {
-    assert.equal(existsSync(path.join(outputRoot, requiredPath)), true, `${requiredPath} should exist`);
+    assert.equal(
+      existsSync(path.join(outputRoot, requiredPath)),
+      true,
+      `${requiredPath} should exist`,
+    );
   }
 
   assert.equal(existsSync(path.join(outputRoot, 'workspace', 'memory', '2026-03-16.md')), false);
@@ -67,7 +71,14 @@ test('import success defaults to human-readable output and supports --json', asy
   await rm(path.dirname(targetRoot), { recursive: true, force: true });
   await runCli(['export', '--workspace', fixture, '--out', outputRoot]);
 
-  const human = await runCli(['import', outputRoot, '--target-workspace', targetRoot, '--agent-id', 'supercoder-copy']);
+  const human = await runCli([
+    'import',
+    outputRoot,
+    '--target-workspace',
+    targetRoot,
+    '--agent-id',
+    'supercoder-copy',
+  ]);
   assert.match(human.stdout, /Import complete/);
   assert.match(human.stdout, /Workspace:/);
   assert.match(human.stdout, /Agent id: supercoder-copy/);
@@ -76,7 +87,15 @@ test('import success defaults to human-readable output and supports --json', asy
 
   await rm(path.dirname(targetRoot), { recursive: true, force: true });
 
-  const json = await runCli(['import', outputRoot, '--target-workspace', targetRoot, '--agent-id', 'supercoder-copy', '--json']);
+  const json = await runCli([
+    'import',
+    outputRoot,
+    '--target-workspace',
+    targetRoot,
+    '--agent-id',
+    'supercoder-copy',
+    '--json',
+  ]);
   const report = JSON.parse(json.stdout);
   assert.equal(report.status, 'ok');
   assert.equal(report.agentId, 'supercoder-copy');
@@ -89,12 +108,31 @@ test('roundtrip export -> import -> validate succeeds with expected warnings', a
   await rm(path.dirname(targetRoot), { recursive: true, force: true });
 
   await runCli(['export', '--workspace', fixture, '--out', outputRoot]);
-  await runCli(['import', outputRoot, '--target-workspace', targetRoot, '--agent-id', 'supercoder-copy']);
-  const { stdout } = await runCli(['validate', '--target-workspace', targetRoot, '--agent-id', 'supercoder-copy', '--json']);
+  await runCli([
+    'import',
+    outputRoot,
+    '--target-workspace',
+    targetRoot,
+    '--agent-id',
+    'supercoder-copy',
+  ]);
+  const { stdout } = await runCli([
+    'validate',
+    '--target-workspace',
+    targetRoot,
+    '--agent-id',
+    'supercoder-copy',
+    '--json',
+  ]);
 
   const report = JSON.parse(stdout);
   assert.equal(report.failed.length, 0);
-  assert.ok(report.warnings.some((warning: string) => warning.includes('Skills are manifest-only')));
+  assert.ok(
+    report.warnings.some((warning: string) => warning.includes('Skills are manifest-only')),
+  );
   assert.ok(report.nextSteps.some((step: string) => step.includes('Channel bindings')));
-  assert.equal(existsSync(path.join(targetRoot, '.openclaw-agent-package', 'agent-definition.json')), true);
+  assert.equal(
+    existsSync(path.join(targetRoot, '.openclaw-agent-package', 'agent-definition.json')),
+    true,
+  );
 });

--- a/tests/run-cli.test.ts
+++ b/tests/run-cli.test.ts
@@ -4,7 +4,10 @@ import test from 'node:test';
 test('runCli exposes child-process guardrails for shared CLI tests', async () => {
   const module = await import('./helpers/run-cli');
 
-  assert.ok('runCliExecOptions' in module, 'runCliExecOptions should be exported for test coverage');
+  assert.ok(
+    'runCliExecOptions' in module,
+    'runCliExecOptions should be exported for test coverage',
+  );
   assert.equal(module.runCliExecOptions.timeout, 30_000);
   assert.equal(module.runCliExecOptions.maxBuffer, 10 * 1024 * 1024);
 });

--- a/tests/skills-detect.test.ts
+++ b/tests/skills-detect.test.ts
@@ -8,7 +8,10 @@ import { scanWorkspace } from '../src/core/workspace-scan';
 const fixture = path.resolve('tests/fixtures/source-workspace');
 const tempWorkspace = path.resolve('tests/tmp/skills-workspace');
 
-async function writeRequiredWorkspaceFiles(root: string, overrides: Partial<Record<string, string>> = {}) {
+async function writeRequiredWorkspaceFiles(
+  root: string,
+  overrides: Partial<Record<string, string>> = {},
+) {
   const files: Record<string, string> = {
     'AGENTS.md': '# AGENTS\n',
     'SOUL.md': '# SOUL\n',
@@ -20,7 +23,9 @@ async function writeRequiredWorkspaceFiles(root: string, overrides: Partial<Reco
   };
 
   await Promise.all(
-    Object.entries(files).map(([filename, content]) => writeFile(path.join(root, filename), content, 'utf8')),
+    Object.entries(files).map(([filename, content]) =>
+      writeFile(path.join(root, filename), content, 'utf8'),
+    ),
   );
 }
 

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -14,20 +14,40 @@ async function exportAndImport() {
   await rm(path.dirname(targetRoot), { recursive: true, force: true });
 
   await runCli(['export', '--workspace', fixture, '--out', packageRoot]);
-  await runCli(['import', packageRoot, '--target-workspace', targetRoot, '--agent-id', 'supercoder-copy']);
+  await runCli([
+    'import',
+    packageRoot,
+    '--target-workspace',
+    targetRoot,
+    '--agent-id',
+    'supercoder-copy',
+  ]);
 }
 
 test('validate command defaults to human-readable output and supports --json', async () => {
   await exportAndImport();
 
-  const human = await runCli(['validate', '--target-workspace', targetRoot, '--agent-id', 'supercoder-copy']);
+  const human = await runCli([
+    'validate',
+    '--target-workspace',
+    targetRoot,
+    '--agent-id',
+    'supercoder-copy',
+  ]);
   assert.match(human.stdout, /Validation: passed/);
   assert.match(human.stdout, /Passed:/);
   assert.match(human.stdout, /Warnings:/);
   assert.match(human.stdout, /Next steps:/);
   assert.equal(human.stdout.includes('"passed"'), false);
 
-  const json = await runCli(['validate', '--target-workspace', targetRoot, '--agent-id', 'supercoder-copy', '--json']);
+  const json = await runCli([
+    'validate',
+    '--target-workspace',
+    targetRoot,
+    '--agent-id',
+    'supercoder-copy',
+    '--json',
+  ]);
   const report = JSON.parse(json.stdout);
   assert.ok(Array.isArray(report.passed));
   assert.ok(Array.isArray(report.failed));
@@ -36,7 +56,14 @@ test('validate command defaults to human-readable output and supports --json', a
 test('validate command reports passed warnings failed and nextSteps', async () => {
   await exportAndImport();
 
-  const { stdout } = await runCli(['validate', '--target-workspace', targetRoot, '--agent-id', 'supercoder-copy', '--json']);
+  const { stdout } = await runCli([
+    'validate',
+    '--target-workspace',
+    targetRoot,
+    '--agent-id',
+    'supercoder-copy',
+    '--json',
+  ]);
   const report = JSON.parse(stdout);
 
   assert.equal(Array.isArray(report.passed), true);
@@ -44,11 +71,21 @@ test('validate command reports passed warnings failed and nextSteps', async () =
   assert.equal(Array.isArray(report.failed), true);
   assert.equal(Array.isArray(report.nextSteps), true);
   assert.equal(report.failed.length, 0);
-  assert.ok(report.warnings.some((warning: string) => warning.includes('Skills are manifest-only')));
+  assert.ok(
+    report.warnings.some((warning: string) => warning.includes('Skills are manifest-only')),
+  );
   assert.ok(report.nextSteps.some((step: string) => step.includes('Channel bindings')));
-  assert.equal(existsSync(path.join(targetRoot, '.openclaw-agent-package', 'agent-definition.json')), true);
+  assert.equal(
+    existsSync(path.join(targetRoot, '.openclaw-agent-package', 'agent-definition.json')),
+    true,
+  );
 
-  const record = JSON.parse(await readFile(path.join(targetRoot, '.openclaw-agent-package', 'agent-definition.json'), 'utf8'));
+  const record = JSON.parse(
+    await readFile(
+      path.join(targetRoot, '.openclaw-agent-package', 'agent-definition.json'),
+      'utf8',
+    ),
+  );
   assert.equal(record.agentId, 'supercoder-copy');
 });
 
@@ -61,21 +98,31 @@ test('validate reports target config consistency when config path is provided', 
   await exportAndImport();
 
   await mkdir(configRoot, { recursive: true });
-  await writeFile(configPath, JSON.stringify({
-    agents: {
-      'supercoder-copy': {
-        id: 'supercoder-copy',
-        name: 'Supercoder',
-        workspace: targetRoot,
+  await writeFile(
+    configPath,
+    JSON.stringify(
+      {
+        agents: {
+          'supercoder-copy': {
+            id: 'supercoder-copy',
+            name: 'Supercoder',
+            workspace: targetRoot,
+          },
+        },
       },
-    },
-  }, null, 2));
+      null,
+      2,
+    ),
+  );
 
   const { stdout } = await runCli([
     'validate',
-    '--target-workspace', targetRoot,
-    '--agent-id', 'supercoder-copy',
-    '--config', configPath,
+    '--target-workspace',
+    targetRoot,
+    '--agent-id',
+    'supercoder-copy',
+    '--config',
+    configPath,
     '--json',
   ]);
   const report = JSON.parse(stdout);
@@ -84,21 +131,31 @@ test('validate reports target config consistency when config path is provided', 
   assert.ok(report.passed.some((entry: string) => entry.includes('OpenClaw config agent present')));
   assert.ok(report.passed.some((entry: string) => entry.includes('workspace matches')));
 
-  await writeFile(configPath, JSON.stringify({
-    agents: {
-      'supercoder-copy': {
-        id: 'supercoder-copy',
-        name: 'Supercoder',
-        workspace: '/tmp/wrong-workspace',
+  await writeFile(
+    configPath,
+    JSON.stringify(
+      {
+        agents: {
+          'supercoder-copy': {
+            id: 'supercoder-copy',
+            name: 'Supercoder',
+            workspace: '/tmp/wrong-workspace',
+          },
+        },
       },
-    },
-  }, null, 2));
+      null,
+      2,
+    ),
+  );
 
   const mismatch = await runCli([
     'validate',
-    '--target-workspace', targetRoot,
-    '--agent-id', 'supercoder-copy',
-    '--config', configPath,
+    '--target-workspace',
+    targetRoot,
+    '--agent-id',
+    'supercoder-copy',
+    '--config',
+    configPath,
     '--json',
   ]);
   const mismatchReport = JSON.parse(mismatch.stdout);
@@ -109,7 +166,14 @@ test('validate reports missing required workspace files as failures', async () =
   await exportAndImport();
   await rm(path.join(targetRoot, 'AGENTS.md'), { force: true });
 
-  const { stdout } = await runCli(['validate', '--target-workspace', targetRoot, '--agent-id', 'supercoder-copy', '--json']);
+  const { stdout } = await runCli([
+    'validate',
+    '--target-workspace',
+    targetRoot,
+    '--agent-id',
+    'supercoder-copy',
+    '--json',
+  ]);
   const report = JSON.parse(stdout);
 
   assert.ok(report.failed.some((failure: string) => failure.includes('AGENTS.md')));

--- a/tests/workspace-scan.test.ts
+++ b/tests/workspace-scan.test.ts
@@ -12,6 +12,9 @@ test('scanWorkspace includes core files and excludes daily memory by default', a
     ['AGENTS.md', 'IDENTITY.md', 'MEMORY.md', 'SOUL.md', 'TOOLS.md', 'USER.md'],
   );
   assert.deepEqual(result.missingOptionalFiles, ['HEARTBEAT.md']);
-  assert.deepEqual(result.excludedFiles.map((file) => file.relativePath), ['memory/2026-03-16.md']);
+  assert.deepEqual(
+    result.excludedFiles.map((file) => file.relativePath),
+    ['memory/2026-03-16.md'],
+  );
   assert.ok(result.ignoredFiles.includes('notes.txt'));
 });


### PR DESCRIPTION
## Summary

- Introduces **@biomejs/biome** as the project's unified lint + format tool, replacing the need for separate ESLint/Prettier setups
- Configured `biome.json` to match existing project conventions: 2-space indent, single quotes, trailing commas, 100-char line width
- Added `npm run lint` (check) and `npm run lint:fix` (auto-fix) scripts to `package.json`
- Auto-fixed all existing formatting issues across 26 source/test files (line width wrapping, trailing commas, argument formatting, one unused import)

## Configuration choices

| Setting | Value | Rationale |
|---------|-------|-----------|
| `indentStyle` | `space` (2) | Matches existing codebase |
| `quoteStyle` | `single` | Matches existing codebase |
| `lineWidth` | `100` | Reasonable for modern screens, avoids excessive wrapping |
| `noForEach` | `off` | Project uses `forEach` in several places |
| `noNonNullAssertion` | `warn` | Awareness without blocking |
| `useNodejsImportProtocol` | `error` | Enforce `node:` protocol for clarity |
| `organizeImports` | `on` | Keeps imports tidy automatically |

## Test plan

- [x] `npm run lint` — zero errors on all 35 checked files
- [x] `npm run lint:fix` — no remaining fixable issues
- [x] `npm run build` — TypeScript compilation passes
- [x] `npm test` — all 39 tests pass

Closes #8

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **Chores**
  * 集成代码质量和格式化工具，配置了项目级别的代码风格规则，包括缩进、行宽、导入整理和代码检查规范。
  * 添加 `lint` 和 `lint:fix` 命令以支持自动代码检查和修复。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->