### PR TITLE
refactor: discriminate import plans

### DIFF
--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -4,7 +4,7 @@ import { executeImport } from '../core/import-exec';
 import { planImport } from '../core/import-plan';
 import { discoverOpenClawConfig } from '../core/openclaw-config';
 import { cleanupTempDir, readPackage } from '../core/package-read';
-import type { ImportPlan } from '../core/types';
+import type { BlockedImportPlan } from '../core/types';
 import { type RenderableCliError, renderableCliErrorBrand } from '../renderable-cli-error';
 import { pushSection } from '../utils/output';
 
@@ -17,7 +17,7 @@ interface ImportOptions {
 }
 
 interface BlockedImportReport
-  extends Pick<ImportPlan, 'failed' | 'requiredInputs' | 'warnings' | 'nextSteps' | 'writePlan'> {
+  extends Pick<BlockedImportPlan, 'failed' | 'requiredInputs' | 'warnings' | 'nextSteps' | 'writePlan'> {
   status: 'blocked';
 }
 

--- a/src/core/import-exec.ts
+++ b/src/core/import-exec.ts
@@ -1,19 +1,13 @@
 import { cp, mkdir, rm } from 'node:fs/promises';
 import path from 'node:path';
+import type { ExecutableImportPlan, ImportResult, ReadPackageResult } from './types';
 import { writeJsonFile } from '../utils/json';
 import { upsertPortableAgentDefinition } from './openclaw-config';
-import type { ImportPlan, ImportResult, ReadPackageResult } from './types';
 
 export async function executeImport(params: {
   pkg: ReadPackageResult;
-  plan: ImportPlan;
+  plan: ExecutableImportPlan;
 }): Promise<ImportResult> {
-  if (!params.plan.canProceed) {
-    throw new Error(
-      `Import plan cannot proceed: ${params.plan.failed.concat(params.plan.requiredInputs.map((item) => item.key)).join(', ')}`,
-    );
-  }
-
   if (params.plan.writePlan.overwriteExisting) {
     await rm(params.plan.writePlan.targetWorkspacePath, { recursive: true, force: true });
   }

--- a/src/core/import-plan.ts
+++ b/src/core/import-plan.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import { pathExists } from '../utils/fs';
 import { loadOpenClawConfig } from './openclaw-config';
-import type { ImportPlan, ReadPackageResult } from './types';
+import type { ImportHints, ImportPlan, ReadPackageResult } from './types';
 
 export async function planImport(params: {
   pkg: ReadPackageResult;
@@ -10,7 +10,7 @@ export async function planImport(params: {
   targetConfigPath?: string;
   force?: boolean;
 }): Promise<ImportPlan> {
-  const requiredInputs = [] as ImportPlan['requiredInputs'];
+  const requiredInputs: ImportHints['requiredInputs'] = [];
   const failed: string[] = [];
   const warnings = [...params.pkg.importHints.warnings];
   const nextSteps = [
@@ -94,8 +94,19 @@ export async function planImport(params: {
     },
   };
 
+  if (requiredInputs.length === 0 && failed.length === 0) {
+    return {
+      canProceed: true,
+      requiredInputs: [],
+      warnings,
+      failed: [],
+      nextSteps,
+      writePlan,
+    };
+  }
+
   return {
-    canProceed: requiredInputs.length === 0 && failed.length === 0,
+    canProceed: false,
     requiredInputs,
     warnings,
     failed,

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -139,14 +139,25 @@ export interface ImportWritePlan {
   };
 }
 
-export interface ImportPlan {
-  canProceed: boolean;
+interface ImportPlanBase {
   requiredInputs: ImportHints['requiredInputs'];
   warnings: string[];
   failed: string[];
   nextSteps: string[];
   writePlan: ImportWritePlan;
 }
+
+export interface BlockedImportPlan extends ImportPlanBase {
+  canProceed: false;
+}
+
+export interface ExecutableImportPlan extends ImportPlanBase {
+  canProceed: true;
+  requiredInputs: [];
+  failed: [];
+}
+
+export type ImportPlan = BlockedImportPlan | ExecutableImportPlan;
 
 export interface ImportResult {
   status: 'ok';

--- a/tests/import-plan.test.ts
+++ b/tests/import-plan.test.ts
@@ -65,6 +65,8 @@ test('planImport refuses collisions by default and only allows overwrite with --
     force: true,
   });
   assert.equal(forced.canProceed, true);
+  assert.deepEqual(forced.requiredInputs, []);
+  assert.deepEqual(forced.failed, []);
   assert.equal(forced.writePlan.overwriteExisting, true);
 });
 
@@ -120,6 +122,8 @@ test('planImport preflights target config agent-id collisions and reports safer 
   });
 
   assert.equal(forced.canProceed, true);
+  assert.deepEqual(forced.requiredInputs, []);
+  assert.deepEqual(forced.failed, []);
   assert.ok(forced.warnings.some((warning) => warning.includes('will be overwritten')));
   assert.equal(forced.writePlan.summary.configAgentCollision, true);
 });


### PR DESCRIPTION
## Summary
- convert ImportPlan to a discriminated union so executable vs blocked plans narrow safely
- update import planning/execution code paths to use the narrowed plan types
- keep the existing import UX unchanged while removing the runtime-only guard path

## Verification
- npm test -- tests/import-plan.test.ts
- npx tsc -p tsconfig.json --noEmit

Closes #15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **重构**
  * 优化了导入流程的类型系统，增强了导入状态的编译时类型安全检查。
  * 扩展了导入配置参数，现支持指定目标工作区路径和代理ID。
  * 改进了导入执行逻辑的条件检查机制。

* **测试**
  * 新增测试覆盖强制导入场景下的验证逻辑。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->