### PR TITLE
chore: sync npm metadata and tests for 0.2.0 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cogineai/clawpacker",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cogineai/clawpacker",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "commander": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,10 @@
     "tsx": "^4.19.3",
     "typescript": "^5.8.2"
   },
-  "repository": "https://github.com/cogine-ai/clawpack",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cogine-ai/clawpack.git"
+  },
   "homepage": "https://github.com/cogine-ai/clawpack",
   "bugs": "https://github.com/cogine-ai/clawpack/issues",
   "license": "MIT"

--- a/tests/branding-metadata.test.ts
+++ b/tests/branding-metadata.test.ts
@@ -11,7 +11,10 @@ test('package metadata is updated for clawpacker npm publishing readiness', asyn
   assert.equal(pkg.name, '@cogineai/clawpacker');
   assert.equal(pkg.bin.clawpacker, 'dist/cli.js');
   assert.equal(pkg.scripts.prepublishOnly, 'npm run build && npm test');
-  assert.equal(pkg.repository, 'https://github.com/cogine-ai/clawpack');
+  assert.deepEqual(pkg.repository, {
+    type: 'git',
+    url: 'git+https://github.com/cogine-ai/clawpack.git',
+  });
   assert.equal(pkg.homepage, 'https://github.com/cogine-ai/clawpack');
   assert.equal(pkg.bugs, 'https://github.com/cogine-ai/clawpack/issues');
   assert.equal(pkg.license, 'MIT');


### PR DESCRIPTION
## Summary
- normalize npm repository metadata with npm pkg fix
- update package-lock.json to 0.2.0
- sync branding metadata test with normalized repository format

## Verification
- npm run build
- npm test