### PR TITLE
fix: align clawpack config loading with OpenClaw semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CLI help text updated to describe runtime modes, safety boundaries, and default behavior (#40)
 - CLI version aligned with package version (#40)
 - README updated with runtime layer documentation: mode descriptions, exclusion rules, path rewriting, import behavior, and package structure (#40)
+- OpenClaw config loading now matches current OpenClaw semantics for JSON5 parsing, `$include` resolution, `OPENCLAW_CONFIG_PATH`, `OPENCLAW_STATE_DIR`, and legacy `clawdbot.json` fallback paths (#53)
 
 ## [0.2.0] - 2026-03-19
 
@@ -85,4 +86,3 @@ Initial alpha release of clawpacker — a portability CLI for OpenClaw agents an
 [Unreleased]: https://github.com/cogine-ai/clawpack/compare/v0.2.0...HEAD
 [0.2.0]: https://github.com/cogine-ai/clawpack/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/cogine-ai/clawpack/releases/tag/v0.1.0
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CLI help text updated to describe runtime modes, safety boundaries, and default behavior (#40)
 - CLI version aligned with package version (#40)
 - README updated with runtime layer documentation: mode descriptions, exclusion rules, path rewriting, import behavior, and package structure (#40)
+
+### Fixed
+
 - OpenClaw config loading now matches current OpenClaw semantics for JSON5 parsing, `$include` resolution, `OPENCLAW_CONFIG_PATH`, `OPENCLAW_STATE_DIR`, and legacy `clawdbot.json` fallback paths (#53)
 
 ## [0.2.0] - 2026-03-19

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@cogineai/clawpacker",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cogineai/clawpacker",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "commander": "^13.1.0",
-        "strip-json-comments": "^5.0.3",
+        "json5": "^2.2.3",
         "tar": "^7.5.11"
       },
       "bin": {
@@ -1089,6 +1089,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -1332,18 +1344,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/strip-json-comments": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
-      "integrity": "sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "commander": "^13.1.0",
-    "strip-json-comments": "^5.0.3",
+    "json5": "^2.2.3",
     "tar": "^7.5.11"
   },
   "devDependencies": {

--- a/src/core/openclaw-config.ts
+++ b/src/core/openclaw-config.ts
@@ -1,7 +1,8 @@
+import { readFileSync } from 'node:fs';
 import { access, mkdir, readFile, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import path from 'node:path';
-import stripJsonComments from 'strip-json-comments';
+import JSON5 from 'json5';
 import type { AgentDefinition } from './types';
 
 export interface AgentConfigEntry {
@@ -36,19 +37,18 @@ export interface MinimalOpenClawConfig {
   [key: string]: unknown;
 }
 
+const NEW_STATE_DIRNAME = '.openclaw';
+const LEGACY_STATE_DIRNAMES = ['.clawdbot'];
+const CONFIG_FILENAME = 'openclaw.json';
+const LEGACY_CONFIG_FILENAMES = ['clawdbot.json'];
+const MAX_INCLUDE_DEPTH = 10;
+
 export async function discoverOpenClawConfig(
   params: { configPath?: string; cwd?: string } = {},
 ): Promise<{ configPath: string }> {
-  const homePath = homedir();
   const candidates = params.configPath
-    ? [path.resolve(params.configPath)]
-    : [
-        ...(process.env.OPENCLAW_CONFIG_PATH
-          ? [path.resolve(process.env.OPENCLAW_CONFIG_PATH)]
-          : []),
-        ...discoverNearbyConfigCandidates(params.cwd),
-        ...(homePath ? [path.resolve(homePath, '.openclaw', 'openclaw.json')] : []),
-      ];
+    ? [resolveUserPath(params.configPath)]
+    : resolveDefaultConfigCandidates();
 
   const seen = new Set<string>();
   const deduped = candidates.filter((candidate) => {
@@ -73,9 +73,10 @@ export async function loadOpenClawConfig(params: {
 }): Promise<{ configPath: string; config: MinimalOpenClawConfig }> {
   const discovered = await discoverOpenClawConfig(params);
   const raw = await readFile(discovered.configPath, 'utf8');
+  const parsed = parseConfigFile(raw);
   return {
     configPath: discovered.configPath,
-    config: parseJsonc(raw) as MinimalOpenClawConfig,
+    config: resolveConfigIncludes(parsed, discovered.configPath) as MinimalOpenClawConfig,
   };
 }
 
@@ -268,7 +269,7 @@ export async function upsertPortableAgentDefinition(params: {
 
   try {
     const raw = await readFile(resolvedPath, 'utf8');
-    config = parseJsonc(raw) as MinimalOpenClawConfig;
+    config = parseConfigFile(raw) as MinimalOpenClawConfig;
     existed = true;
   } catch {}
 
@@ -340,9 +341,8 @@ export async function upsertPortableAgentDefinition(params: {
   return { configPath: resolvedPath, created: !existed, updated: existed };
 }
 
-function parseJsonc(value: string): unknown {
-  const withoutComments = stripJsonComments(value);
-  return JSON.parse(withoutComments);
+function parseConfigFile(value: string): unknown {
+  return JSON5.parse(value);
 }
 
 function extractOpenClawVersion(config: MinimalOpenClawConfig): string | undefined {
@@ -386,30 +386,6 @@ function findAgentByWorkspace(
   return basenameMatches.length === 1 ? basenameMatches[0] : undefined;
 }
 
-function discoverNearbyConfigCandidates(cwd?: string): string[] {
-  if (!cwd) return [];
-
-  const resolvedCwd = path.resolve(cwd);
-  const resolvedHome = process.env.HOME ? path.resolve(process.env.HOME) : undefined;
-  const candidates: string[] = [];
-  let current = resolvedCwd;
-
-  for (let depth = 0; depth < 5; depth += 1) {
-    if (resolvedHome && current === resolvedHome) {
-      break;
-    }
-
-    candidates.push(path.join(current, '.openclaw', 'openclaw.json'));
-    candidates.push(path.join(current, 'openclaw.json'));
-
-    const parent = path.dirname(current);
-    if (parent === current) break;
-    current = parent;
-  }
-
-  return candidates;
-}
-
 function resolveConfigWorkspacePath(workspace: string | undefined, configPath?: string): string | undefined {
   if (!workspace) return undefined;
   if (path.isAbsolute(workspace)) return path.resolve(workspace);
@@ -423,4 +399,178 @@ function toTitleCase(value: string): string {
     .filter(Boolean)
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
     .join(' ');
+}
+
+function resolveDefaultConfigCandidates(): string[] {
+  const explicitConfigPath = process.env.OPENCLAW_CONFIG_PATH?.trim();
+  if (explicitConfigPath) {
+    return [resolveUserPath(explicitConfigPath)];
+  }
+
+  const stateDirOverride = process.env.OPENCLAW_STATE_DIR?.trim();
+  if (stateDirOverride) {
+    return configCandidatesForStateDir(resolveUserPath(stateDirOverride));
+  }
+
+  const homePath = homedir();
+  if (!homePath) return [];
+
+  const stateDirs = [
+    path.join(homePath, NEW_STATE_DIRNAME),
+    ...LEGACY_STATE_DIRNAMES.map((dirname) => path.join(homePath, dirname)),
+  ];
+
+  return stateDirs.flatMap((stateDir) => configCandidatesForStateDir(path.resolve(stateDir)));
+}
+
+function configCandidatesForStateDir(stateDir: string): string[] {
+  return [
+    path.join(stateDir, CONFIG_FILENAME),
+    ...LEGACY_CONFIG_FILENAMES.map((filename) => path.join(stateDir, filename)),
+  ];
+}
+
+function resolveUserPath(input: string): string {
+  const trimmed = input.trim();
+  if (trimmed === '~') {
+    return path.resolve(homedir());
+  }
+
+  if (trimmed.startsWith('~/')) {
+    return path.resolve(homedir(), trimmed.slice(2));
+  }
+
+  return path.resolve(trimmed);
+}
+
+function resolveConfigIncludes(config: unknown, configPath: string): unknown {
+  return new IncludeProcessor(configPath, path.resolve(path.dirname(configPath))).process(config);
+}
+
+class IncludeProcessor {
+  private readonly visited: Set<string>;
+
+  constructor(
+    private readonly basePath: string,
+    private readonly rootDir: string,
+    private readonly depth = 0,
+    visited: Iterable<string> = [],
+  ) {
+    this.visited = new Set([...visited, path.normalize(basePath)]);
+  }
+
+  process(value: unknown): unknown {
+    if (Array.isArray(value)) {
+      return value.map((item) => this.process(item));
+    }
+
+    if (!isPlainObject(value)) {
+      return value;
+    }
+
+    if (!('$include' in value)) {
+      return Object.fromEntries(
+        Object.entries(value).map(([key, nestedValue]) => [key, this.process(nestedValue)]),
+      );
+    }
+
+    return this.processIncludedObject(value);
+  }
+
+  private processIncludedObject(value: Record<string, unknown>): unknown {
+    const includeValue = value.$include;
+    const siblingEntries = Object.entries(value).filter(([key]) => key !== '$include');
+    const includedValue = this.resolveIncludeValue(includeValue);
+
+    if (siblingEntries.length === 0) {
+      return includedValue;
+    }
+
+    if (!isPlainObject(includedValue)) {
+      throw new Error('OpenClaw config $include sibling keys require an included object value.');
+    }
+
+    const processedSiblings = Object.fromEntries(
+      siblingEntries.map(([key, nestedValue]) => [key, this.process(nestedValue)]),
+    );
+
+    return deepMerge(includedValue, processedSiblings);
+  }
+
+  private resolveIncludeValue(includeValue: unknown): unknown {
+    if (typeof includeValue === 'string') {
+      return this.loadIncludedFile(includeValue);
+    }
+
+    if (Array.isArray(includeValue)) {
+      return includeValue.reduce<unknown>((merged, item) => {
+        if (typeof item !== 'string') {
+          throw new Error(`OpenClaw config $include items must be strings; received ${typeof item}.`);
+        }
+
+        return deepMerge(merged, this.loadIncludedFile(item));
+      }, {});
+    }
+
+    throw new Error(`OpenClaw config $include must be a string or string[]; received ${typeof includeValue}.`);
+  }
+
+  private loadIncludedFile(includePath: string): unknown {
+    if (this.depth >= MAX_INCLUDE_DEPTH) {
+      throw new Error(`OpenClaw config maximum include depth (${MAX_INCLUDE_DEPTH}) exceeded at ${includePath}.`);
+    }
+
+    const resolvedPath = resolveIncludedFilePath(this.basePath, includePath, this.rootDir);
+    const normalizedPath = path.normalize(resolvedPath);
+
+    if (this.visited.has(normalizedPath)) {
+      throw new Error(`OpenClaw config circular $include detected: ${[...this.visited, normalizedPath].join(' -> ')}`);
+    }
+
+    const nextProcessor = new IncludeProcessor(
+      normalizedPath,
+      this.rootDir,
+      this.depth + 1,
+      this.visited,
+    );
+
+    return nextProcessor.process(parseConfigFile(readFileSync(normalizedPath, 'utf8')));
+  }
+}
+
+function resolveIncludedFilePath(basePath: string, includePath: string, rootDir: string): string {
+  const resolvedPath = path.isAbsolute(includePath)
+    ? path.resolve(includePath)
+    : path.resolve(path.dirname(basePath), includePath);
+
+  if (!isPathInside(rootDir, resolvedPath)) {
+    throw new Error(`OpenClaw config $include path escapes the config root: ${includePath}`);
+  }
+
+  return resolvedPath;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function deepMerge(target: unknown, source: unknown): unknown {
+  if (Array.isArray(target) && Array.isArray(source)) {
+    return [...target, ...source];
+  }
+
+  if (isPlainObject(target) && isPlainObject(source)) {
+    const result: Record<string, unknown> = { ...target };
+    for (const [key, value] of Object.entries(source)) {
+      result[key] = key in result ? deepMerge(result[key], value) : value;
+    }
+    return result;
+  }
+
+  return source;
+}
+
+function isPathInside(rootDir: string, candidatePath: string): boolean {
+  const relative = path.relative(path.resolve(rootDir), path.resolve(candidatePath));
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
 }

--- a/tests/fixtures/openclaw-config/includes/agents/supercoder.json5
+++ b/tests/fixtures/openclaw-config/includes/agents/supercoder.json5
@@ -1,0 +1,8 @@
+{
+  $include: "../shared/agent-common.json5",
+  id: "supercoder",
+  name: "Supercoder",
+  model: {
+    default: "openai-codex/gpt-5.4",
+  },
+}

--- a/tests/fixtures/openclaw-config/includes/root.json
+++ b/tests/fixtures/openclaw-config/includes/root.json
@@ -1,0 +1,12 @@
+{
+  $include: "./shared/base.json5",
+  agents: {
+    list: [
+      {
+        $include: "./agents/supercoder.json5",
+        workspace: "./workspaces/source-workspace",
+      },
+    ],
+  },
+  tags: ["root"],
+}

--- a/tests/fixtures/openclaw-config/includes/shared/agent-common.json5
+++ b/tests/fixtures/openclaw-config/includes/shared/agent-common.json5
@@ -1,0 +1,8 @@
+{
+  identity: {
+    name: "Nested Identity",
+  },
+  tools: {
+    profile: "strict",
+  },
+}

--- a/tests/fixtures/openclaw-config/includes/shared/base.json5
+++ b/tests/fixtures/openclaw-config/includes/shared/base.json5
@@ -1,0 +1,7 @@
+{
+  openclawVersion: "2026.4.9",
+  runtime: {
+    transport: "stdio",
+  },
+  tags: ["base"],
+}

--- a/tests/openclaw-config.test.ts
+++ b/tests/openclaw-config.test.ts
@@ -16,6 +16,7 @@ import { runCli } from './helpers/run-cli';
 
 const fixtureConfig = path.resolve('tests/fixtures/openclaw-config/source-config.jsonc');
 const fixtureWorkspace = path.resolve('tests/fixtures/source-workspace');
+const includeFixtureConfig = path.resolve('tests/fixtures/openclaw-config/includes/root.json');
 const inspectTarget = path.resolve('tests/tmp/inspect-output.json');
 const importTargetRoot = path.resolve('tests/tmp/config-import-target');
 const importWorkspace = path.join(importTargetRoot, 'workspace-supercoder-imported');
@@ -40,8 +41,10 @@ test('discoverOpenClawConfig resolves explicit configPath', async () => {
 test('discoverOpenClawConfig respects OPENCLAW_CONFIG_PATH env var', async () => {
   const configPath = await writeJsoncFixture('env-var-config.json', '{}');
   const original = process.env.OPENCLAW_CONFIG_PATH;
+  const originalStateDir = process.env.OPENCLAW_STATE_DIR;
   try {
     process.env.OPENCLAW_CONFIG_PATH = configPath;
+    process.env.OPENCLAW_STATE_DIR = path.join(parserFixtureRoot, 'ignored-state-dir');
     const discovered = await discoverOpenClawConfig();
     assert.equal(discovered.configPath, configPath);
   } finally {
@@ -49,6 +52,12 @@ test('discoverOpenClawConfig respects OPENCLAW_CONFIG_PATH env var', async () =>
       delete process.env.OPENCLAW_CONFIG_PATH;
     } else {
       process.env.OPENCLAW_CONFIG_PATH = original;
+    }
+
+    if (originalStateDir === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = originalStateDir;
     }
   }
 });
@@ -82,26 +91,73 @@ test('discoverOpenClawConfig throws when no config found', async () => {
   }
 });
 
-test('discoverOpenClawConfig discovers nearby config from cwd', async () => {
-  const instanceRoot = path.join(parserFixtureRoot, 'nearby-instance');
-  const workspaceRoot = path.join(instanceRoot, 'workspaces', 'workspace-demo');
-  const configPath = path.join(instanceRoot, '.openclaw', 'openclaw.json');
+test('discoverOpenClawConfig resolves config from OPENCLAW_STATE_DIR and falls back to legacy filename', async () => {
+  const stateDir = path.join(parserFixtureRoot, 'state-dir-override');
+  const legacyConfigPath = path.join(stateDir, 'clawdbot.json');
 
-  await rm(instanceRoot, { recursive: true, force: true });
-  await mkdir(workspaceRoot, { recursive: true });
-  await mkdir(path.dirname(configPath), { recursive: true });
-  await writeFile(configPath, '{}', 'utf8');
+  await rm(stateDir, { recursive: true, force: true });
+  await mkdir(stateDir, { recursive: true });
+  await writeFile(legacyConfigPath, '{}', 'utf8');
 
-  const original = process.env.OPENCLAW_CONFIG_PATH;
+  const originalConfigPath = process.env.OPENCLAW_CONFIG_PATH;
+  const originalStateDir = process.env.OPENCLAW_STATE_DIR;
   try {
     delete process.env.OPENCLAW_CONFIG_PATH;
-    const discovered = await discoverOpenClawConfig({ cwd: workspaceRoot });
-    assert.equal(discovered.configPath, configPath);
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+
+    const discovered = await discoverOpenClawConfig();
+    assert.equal(discovered.configPath, legacyConfigPath);
   } finally {
-    if (original === undefined) {
+    if (originalConfigPath === undefined) {
       delete process.env.OPENCLAW_CONFIG_PATH;
     } else {
-      process.env.OPENCLAW_CONFIG_PATH = original;
+      process.env.OPENCLAW_CONFIG_PATH = originalConfigPath;
+    }
+
+    if (originalStateDir === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = originalStateDir;
+    }
+  }
+});
+
+test('discoverOpenClawConfig falls back to the legacy state dir when canonical state dir is absent', async () => {
+  const fakeHome = path.join(parserFixtureRoot, 'legacy-home');
+  const legacyDir = path.join(fakeHome, '.clawdbot');
+  const legacyConfigPath = path.join(legacyDir, 'clawdbot.json');
+
+  await rm(fakeHome, { recursive: true, force: true });
+  await mkdir(legacyDir, { recursive: true });
+  await writeFile(legacyConfigPath, '{}', 'utf8');
+
+  const originalConfigPath = process.env.OPENCLAW_CONFIG_PATH;
+  const originalStateDir = process.env.OPENCLAW_STATE_DIR;
+  const originalHome = process.env.HOME;
+  try {
+    delete process.env.OPENCLAW_CONFIG_PATH;
+    delete process.env.OPENCLAW_STATE_DIR;
+    process.env.HOME = fakeHome;
+
+    const discovered = await discoverOpenClawConfig();
+    assert.equal(discovered.configPath, legacyConfigPath);
+  } finally {
+    if (originalConfigPath === undefined) {
+      delete process.env.OPENCLAW_CONFIG_PATH;
+    } else {
+      process.env.OPENCLAW_CONFIG_PATH = originalConfigPath;
+    }
+
+    if (originalStateDir === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = originalStateDir;
+    }
+
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
     }
   }
 });
@@ -134,6 +190,20 @@ test('loadOpenClawConfig parses single-agent format', async () => {
   const loaded = await loadOpenClawConfig({ configPath });
   assert.ok(loaded.config.agent, 'agent field should exist');
   assert.equal(loaded.config.agent.name, 'Solo Agent');
+});
+
+test('loadOpenClawConfig parses JSON5 and resolves nested includes relative to each included file', async () => {
+  const loaded = await loadOpenClawConfig({ configPath: includeFixtureConfig });
+  const agent = loaded.config.agents?.list?.find((entry) => entry.id === 'supercoder');
+
+  assert.equal(loaded.config.openclawVersion, '2026.4.9');
+  assert.equal(loaded.config.runtime?.transport, 'stdio');
+  assert.deepEqual(loaded.config.tags, ['base', 'root']);
+  assert.equal(agent?.name, 'Supercoder');
+  assert.equal(agent?.identity?.name, 'Nested Identity');
+  assert.equal(agent?.tools?.profile, 'strict');
+  assert.equal(agent?.workspace, './workspaces/source-workspace');
+  assert.equal(agent?.model?.default, 'openai-codex/gpt-5.4');
 });
 
 // --- resolveAgentFromConfig ---


### PR DESCRIPTION
## Summary
- align `openclaw-config` discovery with current OpenClaw config/state path semantics
- switch config parsing to JSON5 and add `$include` resolution with nested fixture coverage
- add tests for `OPENCLAW_CONFIG_PATH`, `OPENCLAW_STATE_DIR`, and legacy `clawdbot.json` fallback

## Testing
- `npm test`
- `npm run build`

Closes #53.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 配置文件现已支持 JSON5 格式，允许注释与更灵活语法
  * 新增 `$include` 指令，支持在配置中包含并合并其他文件以实现模块化配置

* **改进**
  * 配置发现策略调整：优先使用 OPENCLAW_CONFIG_PATH，其次 OPENCLAW_STATE_DIR，最后在用户主目录搜索
  * 增强对旧版配置文件路径的兼容性

* **变更/维护**
  * 运行时依赖由 strip-json-comments 更换为 json5

* **测试**
  * 增补并更新了配置发现与包含解析相关的测试用例
<!-- end of auto-generated comment: release notes by coderabbit.ai -->