### PR TITLE
fix: align multi-agent config semantics

### DIFF
--- a/src/core/import-plan.ts
+++ b/src/core/import-plan.ts
@@ -2,7 +2,12 @@ import { lstat, readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { pathExists } from '../utils/fs';
 import { RUNTIME_ALWAYS_EXCLUDE } from './constants';
-import { hasAgentInConfig, loadOpenClawConfig, resolveAgentFromConfig } from './openclaw-config';
+import {
+  hasAgentInConfig,
+  listConfiguredAgents,
+  loadOpenClawConfig,
+  resolveEffectiveAgentDir,
+} from './openclaw-config';
 import { computePathRewrites } from './path-rewrite';
 import type {
   ImportHints,
@@ -366,11 +371,7 @@ async function resolveTargetAgentDir(params: {
     const { config, configPath } = await loadOpenClawConfig({
       configPath: params.targetConfigPath,
     });
-    const resolved = resolveAgentFromConfig(config, params.targetAgentId);
-    if (resolved?.agent.agentDir) {
-      const ad = resolved.agent.agentDir;
-      return path.isAbsolute(ad) ? ad : path.resolve(path.dirname(configPath), ad);
-    }
+    return resolveEffectiveAgentDir(config, configPath, params.targetAgentId);
   } catch {}
 
   return undefined;
@@ -389,16 +390,13 @@ async function isAgentDirClaimedByOther(params: {
     const { config, configPath } = await loadOpenClawConfig({
       configPath: params.targetConfigPath,
     });
-    const entries = config.agents?.list ?? (config.agent ? [config.agent] : []);
+    const entries = listConfiguredAgents(config);
 
     for (const entry of entries) {
-      const entryId = entry.id ?? 'default';
+      const entryId = entry.resolvedId;
       if (entryId === params.targetAgentId) continue;
-      if (!entry.agentDir) continue;
-
-      const resolved = path.isAbsolute(entry.agentDir)
-        ? entry.agentDir
-        : path.resolve(path.dirname(configPath), entry.agentDir);
+      const resolved = resolveEffectiveAgentDir(config, configPath, entryId);
+      if (!resolved) continue;
 
       if (resolved === params.targetAgentDir) return true;
     }

--- a/src/core/import-plan.ts
+++ b/src/core/import-plan.ts
@@ -400,6 +400,19 @@ async function isAgentDirClaimedByOther(params: {
 
       if (resolved === params.targetAgentDir) return true;
     }
+
+    if (config.agents?.list?.length && config.agent?.agentDir) {
+      const legacyEntryId = config.agent.id ?? 'default';
+      if (legacyEntryId !== params.targetAgentId) {
+        const resolvedLegacyAgentDir = path.isAbsolute(config.agent.agentDir)
+          ? path.resolve(config.agent.agentDir)
+          : path.resolve(path.dirname(configPath), config.agent.agentDir);
+
+        if (resolvedLegacyAgentDir === params.targetAgentDir) {
+          return true;
+        }
+      }
+    }
   } catch {}
 
   return false;

--- a/src/core/openclaw-config.ts
+++ b/src/core/openclaw-config.ts
@@ -42,6 +42,21 @@ const LEGACY_STATE_DIRNAMES = ['.clawdbot'];
 const CONFIG_FILENAME = 'openclaw.json';
 const LEGACY_CONFIG_FILENAMES = ['clawdbot.json'];
 const MAX_INCLUDE_DEPTH = 10;
+const DEFAULT_MAIN_AGENT_ID = 'main';
+const DEFAULT_WORKSPACE_DIRNAME = 'workspace';
+const DEFAULT_AGENTS_DIRNAME = 'agents';
+const DEFAULT_AGENT_LEAF_DIRNAME = 'agent';
+
+type ResolvedAgentEntry = {
+  agent: AgentConfigEntry;
+  resolvedId: string;
+  source: 'agents.list' | 'legacy-agent';
+};
+
+type ResolvedPortableAgentEntry = ResolvedAgentEntry & {
+  effectiveAgent: AgentConfigEntry;
+  defaultDerivedFields: string[];
+};
 
 export async function discoverOpenClawConfig(
   params: { configPath?: string; cwd?: string } = {},
@@ -107,11 +122,7 @@ export async function resolveAgentDir(params: {
         : workspacePath
           ? findAgentByWorkspace(config, workspacePath, configPath)
           : undefined) ?? resolveAgentFromConfig(config, params.agentId);
-
-    if (!resolved?.agent.agentDir) return undefined;
-
-    const agentDir = resolved.agent.agentDir;
-    return path.isAbsolute(agentDir) ? agentDir : path.resolve(path.dirname(configPath), agentDir);
+    return resolved ? resolveAgentDirForEntry(config, configPath, resolved) : undefined;
   } catch {
     return undefined;
   }
@@ -120,31 +131,20 @@ export async function resolveAgentDir(params: {
 export function resolveAgentFromConfig(
   config: MinimalOpenClawConfig,
   agentId?: string,
-): { agent: AgentConfigEntry; resolvedId: string } | undefined {
-  if (config.agent) {
-    const singleId = config.agent.id ?? 'default';
-    if (!agentId || agentId === singleId) {
-      return { agent: config.agent, resolvedId: singleId };
+): ResolvedAgentEntry | undefined {
+  if (config.agents?.list?.length) {
+    const currentAgents = listConfiguredAgents(config);
+    if (agentId) {
+      return currentAgents.find((entry) => entry.resolvedId === agentId);
     }
+
+    return resolveDefaultCurrentAgent(config);
   }
 
-  if (config.agents?.list) {
-    for (const entry of config.agents.list) {
-      const entryId = entry.id;
-      if (!entryId) continue;
-      if (agentId === entryId) {
-        return { agent: entry, resolvedId: entryId };
-      }
-    }
-    if (!agentId) {
-      const defaultAgent = config.agents.list.find((e) => e.default) ?? config.agents.list[0];
-      if (defaultAgent) {
-        return { agent: defaultAgent, resolvedId: defaultAgent.id ?? 'default' };
-      }
-    }
-  }
-
-  return undefined;
+  const legacyAgent = resolveLegacyAgent(config);
+  if (!legacyAgent) return undefined;
+  if (agentId && agentId !== legacyAgent.resolvedId) return undefined;
+  return legacyAgent;
 }
 
 export function extractPortableAgentDefinition(params: {
@@ -167,7 +167,10 @@ export function extractPortableAgentDefinition(params: {
     resolveAgentFromConfig(params.config, params.agentId);
 
   const selectedAgentId = resolved?.resolvedId ?? params.agentId ?? fallbackId;
-  const sourceAgent = resolved?.agent;
+  const resolvedPortable = resolved
+    ? resolvePortableAgentEntry(params.config, params.configPath, resolved)
+    : undefined;
+  const sourceAgent = resolvedPortable?.effectiveAgent;
 
   if (!sourceAgent) {
     throw new Error(`Agent not found in OpenClaw config: ${selectedAgentId}`);
@@ -247,7 +250,14 @@ export function extractPortableAgentDefinition(params: {
       ...(extraFields.memorySearch ? { 'agent.memorySearch': 'portable' } : {}),
       'agent.secrets': 'excluded',
     },
-    notes: [`Portable agent definition derived from OpenClaw config at ${params.configPath}.`],
+    notes: [
+      `Portable agent definition derived from OpenClaw config at ${params.configPath}.`,
+      ...(resolvedPortable?.defaultDerivedFields.length
+        ? [
+            `Applied agents.defaults to derive effective fields: ${resolvedPortable.defaultDerivedFields.join(', ')}.`,
+          ]
+        : []),
+    ],
   };
 }
 
@@ -315,25 +325,25 @@ export async function upsertPortableAgentDefinition(params: {
       : {}),
   };
 
-  if (config.agents?.list) {
-    const idx = config.agents.list.findIndex((e) => e.id === params.targetAgentId);
-    if (idx >= 0) {
-      config.agents.list[idx] = newEntry;
-    } else {
-      config.agents.list.push(newEntry);
-    }
-  } else if (config.agent) {
-    const existingId = config.agent.id ?? 'default';
-    if (existingId === params.targetAgentId) {
-      config.agent = newEntry;
-    } else {
-      const existingEntry: AgentConfigEntry = { id: existingId, ...config.agent };
-      delete (config as Record<string, unknown>).agent;
-      config.agents = { list: [existingEntry, newEntry] };
-    }
-  } else {
-    config.agents = { list: [newEntry] };
+  if (!config.agents) {
+    config.agents = {};
   }
+
+  const existingEntries = listConfiguredAgents(config);
+  const normalizedEntries: AgentConfigEntry[] =
+    existingEntries.length > 0
+      ? existingEntries.map((entry) => ({ ...entry.agent, id: entry.resolvedId }))
+      : [];
+
+  const idx = normalizedEntries.findIndex((entry) => entry.id === params.targetAgentId);
+  if (idx >= 0) {
+    normalizedEntries[idx] = newEntry;
+  } else {
+    normalizedEntries.push(newEntry);
+  }
+
+  config.agents.list = normalizedEntries;
+  delete (config as Record<string, unknown>).agent;
 
   await mkdir(path.dirname(resolvedPath), { recursive: true });
   await writeFile(resolvedPath, `${JSON.stringify(config, null, 2)}\n`, 'utf8');
@@ -359,31 +369,23 @@ function findAgentByWorkspace(
   config: MinimalOpenClawConfig,
   workspacePath: string,
   configPath?: string,
-): { agent: AgentConfigEntry; resolvedId: string } | undefined {
+): ResolvedAgentEntry | undefined {
   const resolvedWorkspacePath = path.resolve(workspacePath);
   const basename = path.basename(resolvedWorkspacePath);
-  const entries = [
-    ...(config.agent ? [{ agent: config.agent, resolvedId: config.agent.id ?? 'default' }] : []),
-    ...(
-      config.agents?.list?.map((entry) => ({
-        agent: entry,
-        resolvedId: entry.id ?? 'default',
-      })) ?? []
-    ),
-  ];
+  const entries = resolveWorkspaceCandidates(config, configPath);
 
-  const exactMatch = entries.find(({ agent }) => {
-    const candidate = resolveConfigWorkspacePath(agent.workspace, configPath);
-    return candidate !== undefined && candidate === resolvedWorkspacePath;
-  });
-  if (exactMatch) return exactMatch;
+  const workspaceMatches = entries
+    .filter(({ workspaceRoot }) => isSameOrDescendantPath(workspaceRoot, resolvedWorkspacePath))
+    .sort((left, right) => right.workspaceRoot.length - left.workspaceRoot.length);
+  if (workspaceMatches.length > 0) {
+    return workspaceMatches[0].entry;
+  }
 
-  const basenameMatches = entries.filter(({ agent }) => {
-    const candidate = resolveConfigWorkspacePath(agent.workspace, configPath);
-    return candidate !== undefined && path.basename(candidate) === basename;
-  });
+  const basenameMatches = entries.filter(
+    ({ workspaceRoot }) => path.basename(workspaceRoot) === basename,
+  );
 
-  return basenameMatches.length === 1 ? basenameMatches[0] : undefined;
+  return basenameMatches.length === 1 ? basenameMatches[0].entry : undefined;
 }
 
 function resolveConfigWorkspacePath(workspace: string | undefined, configPath?: string): string | undefined {
@@ -391,6 +393,204 @@ function resolveConfigWorkspacePath(workspace: string | undefined, configPath?: 
   if (path.isAbsolute(workspace)) return path.resolve(workspace);
   if (configPath) return path.resolve(path.dirname(configPath), workspace);
   return path.resolve(workspace);
+}
+
+export function listConfiguredAgents(config: MinimalOpenClawConfig): ResolvedAgentEntry[] {
+  const currentAgents = config.agents?.list?.length
+    ? config.agents.list.map((entry) => ({
+        agent: entry,
+        resolvedId: resolveListAgentId(entry),
+        source: 'agents.list' as const,
+      }))
+    : [];
+  if (currentAgents.length > 0) {
+    return currentAgents;
+  }
+
+  const legacyAgent = resolveLegacyAgent(config);
+  return legacyAgent ? [legacyAgent] : [];
+}
+
+export function resolveEffectiveAgentDir(
+  config: MinimalOpenClawConfig,
+  configPath: string,
+  agentId: string,
+): string | undefined {
+  const resolved = resolveAgentFromConfig(config, agentId);
+  return resolved ? resolveAgentDirForEntry(config, configPath, resolved) : undefined;
+}
+
+export function resolveEffectiveWorkspace(
+  config: MinimalOpenClawConfig,
+  configPath: string,
+  agentId: string,
+): string | undefined {
+  const resolved = resolveAgentFromConfig(config, agentId);
+  return resolved ? resolveWorkspaceForEntry(config, configPath, resolved) : undefined;
+}
+
+function resolveDefaultCurrentAgent(config: MinimalOpenClawConfig): ResolvedAgentEntry | undefined {
+  if (!config.agents?.list?.length) return undefined;
+
+  const defaultAgent = config.agents.list.find((entry) => entry.default) ?? config.agents.list[0];
+  return {
+    agent: defaultAgent,
+    resolvedId: resolveListAgentId(defaultAgent),
+    source: 'agents.list',
+  };
+}
+
+function resolveLegacyAgent(config: MinimalOpenClawConfig): ResolvedAgentEntry | undefined {
+  if (!config.agent) return undefined;
+  return {
+    agent: config.agent,
+    resolvedId: config.agent.id ?? 'default',
+    source: 'legacy-agent',
+  };
+}
+
+function resolvePortableAgentEntry(
+  config: MinimalOpenClawConfig,
+  configPath: string,
+  entry: ResolvedAgentEntry,
+): ResolvedPortableAgentEntry {
+  if (entry.source !== 'agents.list') {
+    return {
+      ...entry,
+      effectiveAgent: { ...entry.agent },
+      defaultDerivedFields: [],
+    };
+  }
+
+  const defaults = config.agents?.defaults ?? {};
+  const effectiveAgent: AgentConfigEntry = { ...entry.agent };
+  const defaultDerivedFields: string[] = [];
+
+  for (const field of [
+    'identity',
+    'model',
+    'tools',
+    'skills',
+    'heartbeat',
+    'sandbox',
+    'runtime',
+    'params',
+    'subagents',
+    'groupChat',
+    'humanDelay',
+    'memorySearch',
+  ] as const) {
+    const defaultValue = defaults[field];
+    const currentValue = effectiveAgent[field];
+    const mergedValue = mergePortableField(defaultValue, currentValue);
+    if (mergedValue !== undefined) {
+      (effectiveAgent as Record<string, unknown>)[field] = mergedValue;
+    }
+    if (currentValue === undefined && defaultValue !== undefined) {
+      defaultDerivedFields.push(`agent.${field}`);
+    }
+  }
+
+  const resolvedWorkspace = resolveWorkspaceForEntry(config, configPath, entry);
+  if (resolvedWorkspace && entry.agent.workspace === undefined && defaults.workspace !== undefined) {
+    defaultDerivedFields.push('agent.workspace');
+  }
+
+  return {
+    ...entry,
+    effectiveAgent,
+    defaultDerivedFields,
+  };
+}
+
+function resolveWorkspaceCandidates(
+  config: MinimalOpenClawConfig,
+  configPath?: string,
+): Array<{ entry: ResolvedAgentEntry; workspaceRoot: string }> {
+  return listConfiguredAgents(config)
+    .map((entry) => {
+      const workspaceRoot = resolveWorkspaceForEntry(config, configPath, entry);
+      return workspaceRoot ? { entry, workspaceRoot } : undefined;
+    })
+    .filter((entry): entry is { entry: ResolvedAgentEntry; workspaceRoot: string } => entry !== undefined);
+}
+
+function resolveWorkspaceForEntry(
+  config: MinimalOpenClawConfig,
+  configPath: string | undefined,
+  entry: { agent: AgentConfigEntry; resolvedId: string },
+): string | undefined {
+  const explicitWorkspace = resolveConfigWorkspacePath(entry.agent.workspace, configPath);
+  if (explicitWorkspace) return explicitWorkspace;
+
+  if (!config.agents?.list?.length) {
+    return undefined;
+  }
+
+  const workspaceRoot = resolveWorkspaceRoot(config, configPath);
+  const defaultAgent = resolveDefaultCurrentAgent(config);
+  return defaultAgent?.resolvedId === entry.resolvedId
+    ? workspaceRoot
+    : path.join(workspaceRoot, entry.resolvedId);
+}
+
+function resolveWorkspaceRoot(config: MinimalOpenClawConfig, configPath?: string): string {
+  return resolveConfigWorkspacePath(
+    typeof config.agents?.defaults?.workspace === 'string'
+      ? config.agents.defaults.workspace
+      : undefined,
+    configPath,
+  ) ?? resolveConfigWorkspacePath(DEFAULT_WORKSPACE_DIRNAME, configPath) ?? path.resolve(DEFAULT_WORKSPACE_DIRNAME);
+}
+
+function resolveAgentDirForEntry(
+  config: MinimalOpenClawConfig,
+  configPath: string,
+  entry: { agent: AgentConfigEntry; resolvedId: string },
+): string | undefined {
+  const explicitAgentDir = resolveConfigWorkspacePath(entry.agent.agentDir, configPath);
+  if (explicitAgentDir) return explicitAgentDir;
+
+  if (!config.agents?.list?.length) {
+    return undefined;
+  }
+
+  const agentDirRoot = resolveConfigWorkspacePath(
+    typeof config.agents?.defaults?.agentDir === 'string'
+      ? config.agents.defaults.agentDir
+      : undefined,
+    configPath,
+  ) ?? path.resolve(path.dirname(configPath), DEFAULT_AGENTS_DIRNAME);
+
+  return path.join(agentDirRoot, entry.resolvedId, DEFAULT_AGENT_LEAF_DIRNAME);
+}
+
+function mergePortableField(defaultValue: unknown, currentValue: unknown): unknown {
+  if (currentValue !== undefined) {
+    if (isPlainObject(defaultValue) && isPlainObject(currentValue)) {
+      return { ...defaultValue, ...currentValue };
+    }
+    return currentValue;
+  }
+
+  if (Array.isArray(defaultValue)) {
+    return [...defaultValue];
+  }
+
+  if (isPlainObject(defaultValue)) {
+    return { ...defaultValue };
+  }
+
+  return defaultValue;
+}
+
+function resolveListAgentId(entry: AgentConfigEntry): string {
+  return entry.id ?? DEFAULT_MAIN_AGENT_ID;
+}
+
+function isSameOrDescendantPath(rootPath: string, candidatePath: string): boolean {
+  const relative = path.relative(rootPath, candidatePath);
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
 }
 
 function toTitleCase(value: string): string {

--- a/src/core/validate.ts
+++ b/src/core/validate.ts
@@ -186,8 +186,6 @@ async function validateRuntimeLayer(
             `OpenClaw config agent ${params.agentId} is missing agentDir field.`,
           );
         }
-      } else {
-        report.failed.push(`OpenClaw config agent ${params.agentId} is missing agentDir field.`);
       }
     } catch {
       report.warnings.push('Could not validate agentDir against OpenClaw config.');

--- a/src/core/validate.ts
+++ b/src/core/validate.ts
@@ -3,7 +3,12 @@ import { pathExists } from '../utils/fs';
 import { readJsonFile } from '../utils/json';
 import { checksumFile } from './checksums';
 import { REQUIRED_WORKSPACE_FILES } from './constants';
-import { loadOpenClawConfig, resolveAgentFromConfig } from './openclaw-config';
+import {
+  loadOpenClawConfig,
+  resolveAgentFromConfig,
+  resolveEffectiveAgentDir,
+  resolveEffectiveWorkspace,
+} from './openclaw-config';
 import type { ValidationReport } from './types';
 
 const AUTH_FILES = ['auth.json', 'auth-profiles.json'];
@@ -97,11 +102,7 @@ export async function validateImportedWorkspace(params: {
         );
       } else {
         report.passed.push(`OpenClaw config agent present: ${params.agentId} (${configPath})`);
-        const resolvedConfigWorkspace = resolved.agent.workspace
-          ? path.isAbsolute(resolved.agent.workspace)
-            ? path.resolve(resolved.agent.workspace)
-            : path.resolve(path.dirname(configPath), resolved.agent.workspace)
-          : undefined;
+        const resolvedConfigWorkspace = resolveEffectiveWorkspace(config, configPath, params.agentId);
         if (!resolvedConfigWorkspace) {
           report.failed.push(
             `OpenClaw config agent workspace missing: ${params.agentId} (${configPath})`,
@@ -172,16 +173,17 @@ async function validateRuntimeLayer(
         configPath: params.targetConfigPath,
       });
       const resolved = resolveAgentFromConfig(config, params.agentId);
-      if (resolved?.agent.agentDir) {
-        const configAgentDir = path.isAbsolute(resolved.agent.agentDir)
-          ? resolved.agent.agentDir
-          : path.resolve(path.dirname(configPath), resolved.agent.agentDir);
-
+      if (resolved) {
+        const configAgentDir = resolveEffectiveAgentDir(config, configPath, params.agentId);
         if (configAgentDir === targetAgentDir) {
           report.passed.push(`OpenClaw config agentDir matches target: ${configAgentDir}`);
-        } else {
+        } else if (configAgentDir) {
           report.failed.push(
             `OpenClaw config agentDir mismatch: expected ${targetAgentDir}, got ${configAgentDir}`,
+          );
+        } else {
+          report.failed.push(
+            `OpenClaw config agent ${params.agentId} is missing agentDir field.`,
           );
         }
       } else {

--- a/tests/agent-extract.test.ts
+++ b/tests/agent-extract.test.ts
@@ -101,3 +101,36 @@ test('uses specified agentId parameter when provided', async () => {
   assert.equal(result.agent.suggestedName, 'Beta');
   assert.equal(result.agent.model?.default, 'gpt-5');
 });
+
+test('extracts effective agent config from agents.defaults + agents.list workspace semantics', async () => {
+  const configPath = path.join(tmpRoot, 'agent-extract-defaults.json');
+  await mkdir(tmpRoot, { recursive: true });
+  await writeFile(
+    configPath,
+    JSON.stringify({
+      identity: { name: 'Shared Identity' },
+      agents: {
+        defaults: {
+          workspace: './workspaces',
+          model: { default: 'gpt-5.4-mini' },
+          skills: ['brainstorming'],
+        },
+        list: [{ id: 'main', default: true }, { id: 'nested-agent', name: 'Nested Agent' }],
+      },
+    }),
+    'utf8',
+  );
+
+  const nestedWorkspace = path.join(tmpRoot, 'workspaces', 'nested-agent', 'child');
+  await mkdir(nestedWorkspace, { recursive: true });
+
+  const result = await extractAgentDefinition(nestedWorkspace, {
+    configPath,
+  });
+
+  assert.equal(result.agent.suggestedId, 'nested-agent');
+  assert.equal(result.agent.suggestedName, 'Nested Agent');
+  assert.equal(result.agent.identity.name, 'Shared Identity');
+  assert.equal(result.agent.model?.default, 'gpt-5.4-mini');
+  assert.deepEqual(result.agent.skills, ['brainstorming']);
+});

--- a/tests/openclaw-config.test.ts
+++ b/tests/openclaw-config.test.ts
@@ -268,6 +268,25 @@ test('resolveAgentFromConfig falls back to first list entry when no default', ()
   assert.equal(result.resolvedId, 'only');
 });
 
+test('resolveAgentFromConfig prefers agents.list over legacy top-level agent when both exist', () => {
+  const config: MinimalOpenClawConfig = {
+    agent: { id: 'legacy', name: 'Legacy', workspace: '/legacy-workspace' },
+    agents: {
+      list: [
+        { id: 'alpha', name: 'Alpha', workspace: '/tmp/alpha' },
+        { id: 'beta', name: 'Beta', workspace: '/tmp/beta', default: true },
+      ],
+    },
+  };
+
+  const selectedDefault = resolveAgentFromConfig(config);
+  assert.ok(selectedDefault);
+  assert.equal(selectedDefault.resolvedId, 'beta');
+
+  const selectedLegacy = resolveAgentFromConfig(config, 'legacy');
+  assert.equal(selectedLegacy, undefined);
+});
+
 test('resolveAgentDir matches the workspace agent when agentId is omitted', async () => {
   const configPath = await writeJsoncFixture(
     'resolve-agent-dir-by-workspace.json',
@@ -354,6 +373,66 @@ test('resolveAgentDir prefers exact workspace path over basename-only match', as
   );
 });
 
+test('resolveAgentDir resolves nested workspace matches using the longest configured workspace root', async () => {
+  const configPath = await writeJsoncFixture(
+    'resolve-agent-dir-longest-root.json',
+    JSON.stringify({
+      agents: {
+        defaults: {
+          workspace: './workspaces',
+          agentDir: './agents',
+        },
+        list: [
+          {
+            id: 'main',
+            default: true,
+          },
+          {
+            id: 'docs',
+            workspace: './workspaces/projects/docs',
+          },
+        ],
+      },
+    }),
+  );
+
+  const nestedDocsWorkspace = path.resolve(path.dirname(configPath), 'workspaces/projects/docs/subtree');
+  const resolved = await resolveAgentDir({
+    configPath,
+    workspacePath: nestedDocsWorkspace,
+  });
+
+  assert.equal(
+    resolved,
+    path.resolve(path.dirname(configPath), 'agents/docs/agent'),
+  );
+});
+
+test('resolveAgentDir derives agentDir from agents.defaults for non-default agents', async () => {
+  const configPath = await writeJsoncFixture(
+    'resolve-agent-dir-default-root.json',
+    JSON.stringify({
+      agents: {
+        defaults: {
+          workspace: './workspaces',
+          agentDir: './agent-data',
+        },
+        list: [{ id: 'main', default: true }, { id: 'nested-agent' }],
+      },
+    }),
+  );
+
+  const resolved = await resolveAgentDir({
+    configPath,
+    agentId: 'nested-agent',
+  });
+
+  assert.equal(
+    resolved,
+    path.resolve(path.dirname(configPath), 'agent-data/nested-agent/agent'),
+  );
+});
+
 // --- hasAgentInConfig ---
 
 test('hasAgentInConfig checks both single and list formats', () => {
@@ -387,6 +466,71 @@ test('extractPortableAgentDefinition extracts from agents.list fixture', async (
   assert.equal(portable.agent.model?.default, 'openai-codex/gpt-5.4');
   assert.ok(portable.notes.some((note) => note.includes('OpenClaw config')));
   assert.equal(portable.fieldClassification['agent.secrets'], 'excluded');
+});
+
+test('extractPortableAgentDefinition resolves agents.defaults workspace roots and portable defaults', async () => {
+  const configPath = await writeJsoncFixture(
+    'extract-defaults-workspace.json',
+    JSON.stringify({
+      identity: { name: 'Shared Identity' },
+      agents: {
+        defaults: {
+          workspace: './workspaces',
+          model: { default: 'openai/gpt-5.4-mini' },
+          skills: ['brainstorming'],
+        },
+        list: [
+          { id: 'main', default: true, name: 'Main Agent' },
+          { id: 'nested-agent', name: 'Nested Agent' },
+        ],
+      },
+    }),
+  );
+
+  const loaded = await loadOpenClawConfig({ configPath });
+  const workspacePath = path.resolve(path.dirname(configPath), 'workspaces/nested-agent');
+  const portable = extractPortableAgentDefinition({
+    config: loaded.config,
+    configPath,
+    workspacePath,
+  });
+
+  assert.equal(portable.agent.suggestedId, 'nested-agent');
+  assert.equal(portable.agent.suggestedName, 'Nested Agent');
+  assert.equal(portable.agent.identity.name, 'Shared Identity');
+  assert.equal(portable.agent.model?.default, 'openai/gpt-5.4-mini');
+  assert.deepEqual(portable.agent.skills, ['brainstorming']);
+  assert.ok(
+    portable.notes.some((note) => note.includes('defaults') && note.includes('agent.model')),
+  );
+});
+
+test('extractPortableAgentDefinition avoids basename collisions by preferring the longest workspace root match', async () => {
+  const configPath = await writeJsoncFixture(
+    'extract-longest-root.json',
+    JSON.stringify({
+      agents: {
+        defaults: {
+          workspace: './workspaces',
+        },
+        list: [
+          { id: 'main', default: true },
+          { id: 'docs', workspace: './workspaces/projects/docs' },
+          { id: 'other-docs', workspace: './elsewhere/docs' },
+        ],
+      },
+    }),
+  );
+
+  const loaded = await loadOpenClawConfig({ configPath });
+  const nestedWorkspace = path.resolve(path.dirname(configPath), 'workspaces/projects/docs/child');
+  const portable = extractPortableAgentDefinition({
+    config: loaded.config,
+    configPath,
+    workspacePath: nestedWorkspace,
+  });
+
+  assert.equal(portable.agent.suggestedId, 'docs');
 });
 
 test('extractPortableAgentDefinition extracts from single-agent config', async () => {
@@ -612,7 +756,7 @@ test('upsertPortableAgentDefinition converts single-agent to multi-agent on new 
   assert.equal(written.agents.list[1].id, 'supercoder-imported');
 });
 
-test('upsertPortableAgentDefinition updates single-agent in place when same id', async () => {
+test('upsertPortableAgentDefinition converts legacy single-agent config to agents.list even when updating the same id', async () => {
   await rm(importTargetRoot, { recursive: true, force: true });
   await mkdir(importTargetRoot, { recursive: true });
   await writeFile(
@@ -629,9 +773,12 @@ test('upsertPortableAgentDefinition updates single-agent in place when same id',
   });
 
   const written = JSON.parse(await readFile(importConfig, 'utf8'));
-  assert.ok(written.agent, 'should keep single-agent format');
-  assert.equal(written.agent.name, 'Supercoder Imported');
-  assert.equal(written.agent.workspace, importWorkspace);
+  assert.equal(written.agent, undefined, 'legacy top-level agent should be normalized away');
+  assert.ok(Array.isArray(written.agents?.list));
+  assert.equal(written.agents.list.length, 1);
+  assert.equal(written.agents.list[0].id, 'supercoder-imported');
+  assert.equal(written.agents.list[0].name, 'Supercoder Imported');
+  assert.equal(written.agents.list[0].workspace, importWorkspace);
 });
 
 test('upsertPortableAgentDefinition refuses duplicate without --force', async () => {

--- a/tests/runtime-import.test.ts
+++ b/tests/runtime-import.test.ts
@@ -247,6 +247,54 @@ test('Runtime import upserts agentDir into config', async () => {
   assert.equal(path.resolve(entry.workspace), path.resolve(targetWorkspace));
 });
 
+test('Runtime import resolves target agentDir from current agents.defaults semantics', async () => {
+  const dir = 'config-derived-agentdir';
+  await cleanup(dir);
+  const pkgRoot = path.join(tmpBase, dir, 'fixture.ocpkg');
+  const targetWorkspace = path.join(tmpBase, dir, 'target-ws');
+  const configPath = path.join(tmpBase, dir, 'openclaw.json');
+  const expectedAgentDir = path.join(tmpBase, dir, 'agent-root', 'rt-derived', 'agent');
+
+  await mkdir(path.dirname(configPath), { recursive: true });
+  await writeFile(
+    configPath,
+    JSON.stringify(
+      {
+        agents: {
+          defaults: {
+            workspace: path.join(tmpBase, dir, 'workspace-root'),
+            agentDir: path.join(tmpBase, dir, 'agent-root'),
+          },
+          list: [{ id: 'main', default: true }, { id: 'rt-derived' }],
+        },
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  const pkg = await buildRuntimeTestPackage(pkgRoot, {
+    runtimeFiles: {
+      'settings.json': '{}',
+    },
+    sourceAgentDir: '/source/agent-dir',
+    sourceWorkspacePath: '/source/workspace',
+  });
+
+  const plan = await planImport({
+    pkg,
+    targetWorkspacePath: targetWorkspace,
+    targetAgentId: 'rt-derived',
+    targetConfigPath: configPath,
+    force: true,
+  });
+
+  assert.equal(plan.canProceed, true);
+  const execPlan = plan as ExecutableImportPlan;
+  assert.equal(execPlan.writePlan.runtimePlan?.targetAgentDir, expectedAgentDir);
+});
+
 test('Runtime import plan fails when no agentDir can be resolved', async () => {
   const dir = 'no-agentdir';
   await cleanup(dir);

--- a/tests/runtime-import.test.ts
+++ b/tests/runtime-import.test.ts
@@ -355,6 +355,55 @@ test('Runtime import blocks when agentDir is claimed by another agent', async ()
   assert.ok(plan.failed.some((f) => f.includes('claimed by another agent')));
 });
 
+test('Runtime import also treats legacy top-level agentDir as occupied', async () => {
+  const dir = 'legacy-dir-claimed';
+  await cleanup(dir);
+  const pkgRoot = path.join(tmpBase, dir, 'fixture.ocpkg');
+  const targetWorkspace = path.join(tmpBase, dir, 'target-ws');
+  const targetAgentDir = path.join(tmpBase, dir, 'shared-agent-dir');
+  const configPath = path.join(tmpBase, dir, 'openclaw.json');
+
+  await mkdir(path.dirname(configPath), { recursive: true });
+  await writeFile(
+    configPath,
+    JSON.stringify(
+      {
+        agent: {
+          id: 'legacy-agent',
+          name: 'Legacy',
+          workspace: '/legacy/workspace',
+          agentDir: targetAgentDir,
+        },
+        agents: {
+          list: [{ id: 'main', default: true, workspace: '/current/workspace' }],
+        },
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  const pkg = await buildRuntimeTestPackage(pkgRoot, {
+    runtimeFiles: {
+      'settings.json': '{}',
+    },
+    sourceAgentDir: '/source/agent-dir',
+    sourceWorkspacePath: '/source/workspace',
+  });
+
+  const plan = await planImport({
+    pkg,
+    targetWorkspacePath: targetWorkspace,
+    targetAgentId: 'imported-agent',
+    targetAgentDir,
+    targetConfigPath: configPath,
+  });
+
+  assert.equal(plan.canProceed, false);
+  assert.ok(plan.failed.some((f) => f.includes('claimed by another agent')));
+});
+
 test('Package with runtime=none does not trigger runtime import', async () => {
   const dir = 'no-runtime';
   await cleanup(dir);

--- a/tests/runtime-validate.test.ts
+++ b/tests/runtime-validate.test.ts
@@ -222,6 +222,39 @@ test('Validate detects agentDir mismatch in config', async () => {
   assert.ok(report.failed.some((f) => f.includes('agentDir mismatch')));
 });
 
+test('Validate does not report missing agentDir field when the config agent is missing', async () => {
+  const dir = 'missing-agent-config';
+  await cleanup(dir);
+  const { targetWorkspace, targetAgentDir, configPath } = await importWithRuntime(dir);
+
+  await writeFile(
+    configPath,
+    JSON.stringify(
+      {
+        agents: {
+          list: [{ id: 'someone-else', workspace: targetWorkspace, agentDir: targetAgentDir }],
+        },
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  const report = await validateImportedWorkspace({
+    targetWorkspacePath: targetWorkspace,
+    agentId: 'rt-val',
+    targetAgentDir,
+    targetConfigPath: configPath,
+  });
+
+  assert.ok(report.failed.some((f) => f.includes('OpenClaw config agent missing: rt-val')));
+  assert.equal(
+    report.failed.some((f) => f.includes('missing agentDir field')),
+    false,
+  );
+});
+
 test('Validate warns about auth files if they exist', async () => {
   const dir = 'auth-warning';
   await cleanup(dir);


### PR DESCRIPTION
## Summary
- rebase OpenClaw config resolution onto `agents.defaults + agents.list` semantics
- prefer longest matching workspace root, treat top-level `agent` as compatibility-only, and normalize imports back to `agents.list`
- align import/runtime validation with effective workspace and agentDir resolution, with regression tests for nested workspaces and basename collisions

## Testing
- `npm test`
- `npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **优化**
  * 统一并简化了代理配置解析与目录/工作区解析，改进了对 legacy 单代理与 agents.list 混合场景的兼容性
  * 改进了工作区匹配算法（优先最长匹配/包含关系），并确保默认值（agents.defaults）能正确继承到代理定义
  * 校验流程更严格地报告缺失或不匹配的代理目录

* **测试**
  * 添加多项覆盖配置解析、代理提取、导入与运行时校验的新测试用例，验证默认继承与冲突检测行为
<!-- end of auto-generated comment: release notes by coderabbit.ai -->