### PR TITLE
Align workspace contract with current OpenClaw docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - OpenClaw config loading now matches current OpenClaw semantics for JSON5 parsing, `$include` resolution, `OPENCLAW_CONFIG_PATH`, `OPENCLAW_STATE_DIR`, and legacy `clawdbot.json` fallback paths (#53)
+- Workspace contract handling now distinguishes core required files from optional OpenClaw files, so missing `BOOT.md`, `BOOTSTRAP.md`, `HEARTBEAT.md`, `MEMORY.md`, and `memory.md` no longer fail validation; `memory/*.md` exclusion is documented as a clawpacker policy (#55)
 
 ## [0.2.0] - 2026-03-19
 

--- a/README.md
+++ b/README.md
@@ -35,9 +35,19 @@ Do **not** treat it as a production-grade backup, archival, or disaster-recovery
 
 Clawpacker uses a **blacklist model** — it includes all files in the workspace (including subdirectories) except those matching explicit exclusion rules.
 
-The following files are recognized as **bootstrap files** and flagged in the manifest:
+The following top-level files are recognized by current OpenClaw docs as **bootstrap files** and are flagged in the manifest when present:
 
 `AGENTS.md`, `SOUL.md`, `IDENTITY.md`, `USER.md`, `TOOLS.md`, `MEMORY.md`, `HEARTBEAT.md`, `BOOTSTRAP.md`
+
+`BOOT.md` is also a documented workspace file, but it is **not** treated as a bootstrap file. If present, clawpacker includes it as a normal workspace file.
+
+For validation purposes, clawpacker only requires the core workspace contract:
+
+`AGENTS.md`, `SOUL.md`, `IDENTITY.md`, `USER.md`, `TOOLS.md`
+
+The following OpenClaw workspace files are treated as **optional** and their absence does not make a workspace invalid:
+
+`BOOT.md`, `BOOTSTRAP.md`, `HEARTBEAT.md`, `MEMORY.md`, `memory.md`, `memory/*.md`
 
 All other workspace files are included as well, preserving directory structure.
 
@@ -61,6 +71,8 @@ Clawpacker excludes the following subdirectories if they appear inside the works
 And these file patterns:
 
 - `memory/*.md` daily logs
+
+The `memory/*.md` exclusion is a **clawpacker product policy**, not an OpenClaw workspace requirement. It exists to keep exports conservative and portable by default.
 
 These rules only apply to contents **within** the scanned workspace directory. The parent `~/.openclaw/` installation and its config files are not part of the workspace scan — OpenClaw config is read separately via `--config` or config discovery.
 
@@ -411,7 +423,7 @@ Clawpacker is designed to be conservative.
 ### Export safety
 
 - all workspace files are included except explicitly excluded directories and patterns
-- daily memory logs (`memory/*.md`) are excluded by default
+- daily memory logs (`memory/*.md`) are excluded by default as a clawpacker portability policy
 - package contents are declared in a manifest instead of hidden in opaque state
 - checksums are generated for integrity verification
 - runtime layer is opt-in via `--runtime-mode`
@@ -433,7 +445,7 @@ Clawpacker is designed to be conservative.
 
 Even after a successful import, you should still:
 
-- review `USER.md`, `TOOLS.md`, and `MEMORY.md`
+- review `USER.md` and `TOOLS.md`, plus `MEMORY.md` if present
 - reinstall any required skills manually
 - reconfigure channel bindings and cron jobs manually
 - run `openclaw doctor`

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -9,10 +9,17 @@ export const REQUIRED_WORKSPACE_FILES = [
   'IDENTITY.md',
   'USER.md',
   'TOOLS.md',
-  'MEMORY.md',
 ] as const;
 
-export const BOOTSTRAP_FILES = new Set([
+export const OPTIONAL_WORKSPACE_FILES = [
+  'BOOT.md',
+  'BOOTSTRAP.md',
+  'HEARTBEAT.md',
+  'MEMORY.md',
+  'memory.md',
+] as const;
+
+export const OPENCLAW_BOOTSTRAP_FILES = new Set([
   'AGENTS.md',
   'SOUL.md',
   'TOOLS.md',
@@ -39,7 +46,7 @@ export interface ExclusionPattern {
 export const EXCLUDED_PATTERNS: ExclusionPattern[] = [
   {
     test: (relativePath) => /^memory\/.*\.md$/.test(relativePath),
-    reason: 'Excluded by daily memory policy',
+    reason: 'Excluded by clawpack default policy: daily memory logs are not exported by default',
   },
 ];
 

--- a/src/core/validate.ts
+++ b/src/core/validate.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import { pathExists } from '../utils/fs';
 import { readJsonFile } from '../utils/json';
 import { checksumFile } from './checksums';
-import { REQUIRED_WORKSPACE_FILES } from './constants';
+import { OPTIONAL_WORKSPACE_FILES, REQUIRED_WORKSPACE_FILES } from './constants';
 import {
   loadOpenClawConfig,
   resolveAgentFromConfig,
@@ -44,6 +44,12 @@ export async function validateImportedWorkspace(params: {
       report.passed.push(`Workspace file present: ${file}`);
     } else {
       report.failed.push(`Missing required workspace file: ${file}`);
+    }
+  }
+
+  for (const file of OPTIONAL_WORKSPACE_FILES) {
+    if (await pathExists(path.join(targetWorkspacePath, file))) {
+      report.passed.push(`Optional workspace file present: ${file}`);
     }
   }
 
@@ -142,7 +148,7 @@ export async function validateImportedWorkspace(params: {
   );
   report.nextSteps.push('Run `openclaw doctor` and manually verify provider/model availability after import.');
   report.nextSteps.push(
-    'Review imported USER.md, TOOLS.md, and MEMORY.md for target-specific adjustments.',
+    'Review imported USER.md and TOOLS.md, plus MEMORY.md if present, for target-specific adjustments.',
   );
 
   return report;

--- a/src/core/workspace-scan.ts
+++ b/src/core/workspace-scan.ts
@@ -1,6 +1,6 @@
 import { readdir } from 'node:fs/promises';
 import path from 'node:path';
-import { BOOTSTRAP_FILES, EXCLUDED_DIRECTORIES, EXCLUDED_PATTERNS } from './constants';
+import { EXCLUDED_DIRECTORIES, EXCLUDED_PATTERNS, OPENCLAW_BOOTSTRAP_FILES } from './constants';
 import type { WorkspaceScanResult } from './types';
 
 export async function scanWorkspace(workspacePath: string): Promise<WorkspaceScanResult> {
@@ -61,7 +61,7 @@ async function collectFiles(
     }
 
     const absolutePath = path.join(rootPath, relativePath);
-    const isBootstrap = BOOTSTRAP_FILES.has(entry.name) && !relativeDirPath;
+    const isBootstrap = OPENCLAW_BOOTSTRAP_FILES.has(entry.name) && !relativeDirPath;
 
     included.push({ relativePath, absolutePath, isBootstrap });
   }

--- a/tests/package-roundtrip.test.ts
+++ b/tests/package-roundtrip.test.ts
@@ -1,9 +1,10 @@
 import assert from 'node:assert/strict';
-import { existsSync, statSync } from 'node:fs';
-import { readdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { readFile, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import test from 'node:test';
 import { readPackageDirectory } from '../src/core/package-read';
+import { scanWorkspace } from '../src/core/workspace-scan';
 import { runCli } from './helpers/run-cli';
 
 const fixture = path.resolve('tests/fixtures/source-workspace');
@@ -174,9 +175,8 @@ test('export -> import roundtrip preserves workspace file contents byte-for-byte
     'bytes-test',
   ]);
 
-  const sourceEntries = await readdir(fixture);
-  const sourceFiles = sourceEntries.filter((entry) => statSync(path.join(fixture, entry)).isFile());
-  for (const file of sourceFiles) {
+  const scan = await scanWorkspace(fixture);
+  for (const file of scan.includedFiles.map((entry) => entry.relativePath)) {
     const original = await readFile(path.join(fixture, file));
     const imported = await readFile(path.join(bytesTargetRoot, file));
     assert.deepEqual(imported, original, `${file} content should be byte-for-byte identical`);

--- a/tests/package-roundtrip.test.ts
+++ b/tests/package-roundtrip.test.ts
@@ -1,9 +1,8 @@
 import assert from 'node:assert/strict';
-import { existsSync } from 'node:fs';
+import { existsSync, statSync } from 'node:fs';
 import { readdir, readFile, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import test from 'node:test';
-import { REQUIRED_WORKSPACE_FILES } from '../src/core/constants';
 import { readPackageDirectory } from '../src/core/package-read';
 import { runCli } from './helpers/run-cli';
 
@@ -176,8 +175,8 @@ test('export -> import roundtrip preserves workspace file contents byte-for-byte
   ]);
 
   const sourceEntries = await readdir(fixture);
-  for (const file of REQUIRED_WORKSPACE_FILES) {
-    if (!sourceEntries.includes(file)) continue;
+  const sourceFiles = sourceEntries.filter((entry) => statSync(path.join(fixture, entry)).isFile());
+  for (const file of sourceFiles) {
     const original = await readFile(path.join(fixture, file));
     const imported = await readFile(path.join(bytesTargetRoot, file));
     assert.deepEqual(imported, original, `${file} content should be byte-for-byte identical`);

--- a/tests/validate-unit.test.ts
+++ b/tests/validate-unit.test.ts
@@ -98,6 +98,57 @@ test('Workspace complete but missing .openclaw-agent-package/agent-definition.js
   }
 });
 
+test('Workspace missing optional OpenClaw files does not fail workspace contract validation', async () => {
+  const workspace = path.join(tmpBase, 'missing-optional-openclaw-files');
+  await createTempWorkspace(workspace, {
+    extraFiles: {
+      '.openclaw-agent-package/agent-definition.json': JSON.stringify({
+        agentId: 'test-agent',
+      }),
+      'BOOT.md': '# BOOT\n',
+    },
+  });
+
+  try {
+    const report = await validateImportedWorkspace({
+      targetWorkspacePath: workspace,
+      agentId: 'test-agent',
+    });
+
+    assert.ok(
+      !report.failed.some((f) => f.includes('Missing required workspace file: MEMORY.md')),
+    );
+  } finally {
+    await cleanupTempWorkspace(workspace);
+  }
+});
+
+test('Workspace with lowercase memory.md fallback is treated as valid', async () => {
+  const workspace = path.join(tmpBase, 'lowercase-memory-fallback');
+  await createTempWorkspace(workspace, {
+    extraFiles: {
+      '.openclaw-agent-package/agent-definition.json': JSON.stringify({
+        agentId: 'test-agent',
+      }),
+      'memory.md': '# memory fallback\n',
+    },
+  });
+
+  try {
+    const report = await validateImportedWorkspace({
+      targetWorkspacePath: workspace,
+      agentId: 'test-agent',
+    });
+
+    assert.ok(report.passed.some((p) => p.includes('Optional workspace file present: memory.md')));
+    assert.ok(
+      !report.failed.some((f) => f.includes('Missing required workspace file: memory.md')),
+    );
+  } finally {
+    await cleanupTempWorkspace(workspace);
+  }
+});
+
 test('agent-definition.json has mismatched agentId - failed contains "mismatch"', async () => {
   const workspace = path.join(tmpBase, 'mismatch-agent-id');
   await createTempWorkspace(workspace, {

--- a/tests/validate-unit.test.ts
+++ b/tests/validate-unit.test.ts
@@ -110,6 +110,9 @@ test('Workspace missing optional OpenClaw files does not fail workspace contract
   });
 
   try {
+    await rm(path.join(workspace, 'MEMORY.md'), { force: true });
+    await rm(path.join(workspace, 'MEMORY.MD'), { force: true });
+
     const report = await validateImportedWorkspace({
       targetWorkspacePath: workspace,
       agentId: 'test-agent',

--- a/tests/workspace-scan.test.ts
+++ b/tests/workspace-scan.test.ts
@@ -17,6 +17,10 @@ test('scanWorkspace includes all files and excludes daily memory by default', as
     result.excludedFiles.map((file) => file.relativePath),
     ['memory/2026-03-16.md'],
   );
+  assert.match(
+    result.excludedFiles[0]?.reason ?? '',
+    /clawpack.*policy/i,
+  );
   for (const name of ['AGENTS.md', 'IDENTITY.md', 'MEMORY.md', 'SOUL.md', 'TOOLS.md', 'USER.md']) {
     const file = result.includedFiles.find((f) => f.relativePath === name);
     assert.ok(file, `${name} should be in includedFiles`);
@@ -113,6 +117,22 @@ test('scanWorkspace handles optional files BOOTSTRAP.md and HEARTBEAT.md when pr
     assert.equal(bootstrap.isBootstrap, true, 'BOOTSTRAP.md should be bootstrap');
     assert.ok(heartbeat, 'HEARTBEAT.md should be in includedFiles');
     assert.equal(heartbeat.isBootstrap, true, 'HEARTBEAT.md should be bootstrap');
+  } finally {
+    await cleanupTempWorkspace(basePath);
+  }
+});
+
+test('scanWorkspace includes BOOT.md but does not mark it as a bootstrap file', async () => {
+  const basePath = path.resolve('tests/tmp/ws-boot-file');
+  await createTempWorkspace(basePath, {
+    extraFiles: { 'BOOT.md': '# BOOT\n' },
+  });
+
+  try {
+    const result = await scanWorkspace(basePath);
+    const boot = result.includedFiles.find((f) => f.relativePath === 'BOOT.md');
+    assert.ok(boot, 'BOOT.md should be included');
+    assert.equal(boot.isBootstrap, false, 'BOOT.md should not be treated as a bootstrap file');
   } finally {
     await cleanupTempWorkspace(basePath);
   }


### PR DESCRIPTION
## Summary
- align workspace validation with the current OpenClaw workspace contract by limiting required files to the core bootstrap set
- treat `BOOT.md`, `BOOTSTRAP.md`, `HEARTBEAT.md`, `MEMORY.md`, and `memory.md` as optional documented workspace files
- keep daily memory exclusion as an explicit clawpack portability policy and update docs/tests accordingly

## Testing
- npm test
- npm run build

Closes #55

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发行说明

* **Bug 修复**
  * 优化工作区合约验证：区分核心必需文件与可选文件，缺失 BOOT.md/BOOTSTRAP.md/HEARTBEAT.md/MEMORY.md/memory.md 不再导致验证失败，MEMORY.md 仅在存在时被检查。

* **文档**
  * 更新 README/CHANGELOG，明确核心文件列表与可选项，并说明 memory/*.md 的排除为打包工具可移植策略。

* **测试**
  * 新增与调整多项测试，覆盖可选文件行为、扫描与字节对比验证。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->