### PR TITLE
Rework runtime modes around source-backed artifacts only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Runtime layer support: `--runtime-mode` flag on `inspect` and `export` commands with three modes — `none`, `default`, and `full` (#38)
-- `default` mode packages `AGENTS.md`, `settings.json`, `prompts/**`, `themes/**`, and `models.json` from the agent's agentDir (#38)
-- `full` mode additionally packages `skills/**` and `extensions/**` (#38)
+- Runtime layer includes `models.json` sanitization, inferred settings analysis, and packaging metadata for the selected runtime slice (#38)
 - `models.json` sanitization: API keys, secrets, `$secretRef` objects, and secret-bearing headers are stripped before packaging (#38)
 - `settings.json` path analysis: path-like values are classified as workspace-internal, agentDir-internal, relative, external-absolute, or host-bound (#38)
 - Runtime scan with safety exclusions: auth files, session data, toolchain artifacts, and temp/log files are always excluded (#38)
@@ -30,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CLI help text updated to describe runtime modes, safety boundaries, and default behavior (#40)
 - CLI version aligned with package version (#40)
 - README updated with runtime layer documentation: mode descriptions, exclusion rules, path rewriting, import behavior, and package structure (#40)
+- Runtime artifact handling now classifies detected agentDir files as `grounded`, `inferred`, or `unsupported`; `default` packages only grounded artifacts, `full` adds inferred artifacts, and `skills/**` plus `extensions/**` are no longer bundled (#58)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -81,19 +81,33 @@ That means Clawpacker records detected skill references (using backtick-quoted r
 
 ### Runtime layer (optional)
 
-In addition to workspace files, OpenClaw agents often have runtime configuration stored in a separate **agentDir** — things like `settings.json`, prompt templates, themes, and model definitions. Clawpacker can optionally package a portable slice of this runtime layer alongside the workspace.
+In addition to workspace files, OpenClaw agents often have runtime configuration stored in a separate **agentDir**. Clawpacker can optionally package a narrow, labeled slice of this runtime layer alongside the workspace.
 
 This is an **optional portability convenience**, not a full backup of the agent runtime directory.
+
+#### Runtime evidence levels
+
+Clawpacker classifies detected runtime files by evidence level:
+
+| Evidence | Meaning | Current files |
+|----------|---------|---------------|
+| `grounded` | Source-backed and aligned with the current runtime contract | `models.json` |
+| `inferred` | Useful convenience files, but not a strong current OpenClaw portability contract | `settings.json`, `prompts/**`, `themes/**` |
+| `unsupported` | Not currently treated as canonical portable per-agent artifacts | `skills/**`, `extensions/**` |
+
+`inspect` and `export` report these buckets explicitly so the runtime layer does not overstate what is officially portable.
 
 #### The three modes
 
 | Mode | What gets packaged | When to use |
 |------|-------------------|-------------|
 | `none` | Nothing from agentDir | You only need workspace files |
-| `default` | `AGENTS.md`, `settings.json`, `prompts/**`, `themes/**`, `models.json` | Most agent transfers (recommended) |
-| `full` | Everything in `default`, plus `skills/**` and `extensions/**` | When the target instance needs locally installed skills or extensions |
+| `default` | Only `grounded` runtime artifacts | Honest default for portability checks and packaging |
+| `full` | `grounded` plus `inferred` runtime artifacts | When you intentionally want extra convenience files and understand they are not an official capability contract |
 
 Use `--runtime-mode <mode>` on `inspect` and `export`. When omitted, `inspect` defaults to `default`; `export` skips the runtime layer unless the flag is explicitly provided.
+
+`full` does **not** include `skills/**` or `extensions/**`. Those are reported as `unsupported`, not packaged.
 
 #### What is always excluded
 
@@ -119,6 +133,8 @@ If sanitization removes everything useful, the file is excluded entirely and a w
 
 #### settings.json path analysis
 
+`settings.json` is an `inferred` artifact, so this analysis runs only when `settings.json` is actually included, for example with `--runtime-mode full`.
+
 Clawpacker analyzes path-like values in `settings.json` and classifies them:
 
 | Classification | Meaning | On import |
@@ -137,7 +153,7 @@ When importing a package that includes a runtime layer:
 - If no target agentDir can be resolved, import **blocks** and tells you what is needed.
 - If runtime files already exist at the target agentDir, import **blocks** unless `--force` is passed. Only allowlisted runtime files are overwritten — auth and session files are never written.
 - If a target OpenClaw config is provided, the agent entry is upserted with the agentDir path.
-- `settings.json` paths referencing the source workspace or agentDir are automatically rewritten to the target paths.
+- `settings.json` paths referencing the source workspace or agentDir are automatically rewritten to the target paths when `settings.json` is present in the package.
 
 Use `--dry-run` to preview the full import plan (including runtime file list, path rewrites, and collision detection) before committing.
 
@@ -234,7 +250,7 @@ What `inspect` tells you:
 - whether a portable agent definition could be derived
 - which fields are portable vs import-time inputs
 - which skills were detected
-- runtime layer contents (when `--runtime-mode` is `default` or `full`)
+- runtime layer contents grouped as `grounded`, `inferred`, and `unsupported` (when `--runtime-mode` is `default` or `full`)
 - warnings you should expect on export/import
 
 ### 2) Export a package
@@ -283,7 +299,10 @@ Output defaults to human-readable text. Add `--json` for machine-readable output
   "manifestPath": ".../example-supercoder.ocpkg/manifest.json",
   "fileCount": 12,
   "runtimeMode": "default",
-  "runtimeFiles": ["AGENTS.md", "settings.json", "prompts/system.md"]
+  "runtimeFiles": ["models.json"],
+  "runtimeGroundedFiles": ["models.json"],
+  "runtimeInferredFiles": ["settings.json", "prompts/system.md"],
+  "runtimeUnsupportedFiles": ["skills/review/SKILL.md"]
 }
 ```
 
@@ -472,23 +491,19 @@ supercoder-template.ocpkg/
     manifest.json
     checksums.json
     path-rewrites.json
-    settings-analysis.json  # present when settings.json was included
+    settings-analysis.json  # present when inferred settings.json was included
     files/
-      AGENTS.md
-      settings.json
       models.json           # sanitized — no API keys or secrets
-      prompts/
+      settings.json         # present only when inferred files are included
+      prompts/              # present only when inferred files are included
         system.md
-      themes/
+      themes/               # present only when inferred files are included
         dark.json
-      skills/               # present only in full mode
-        my-skill/
-          SKILL.md
 ```
 
 The `workspace/` directory mirrors the source workspace structure. All non-excluded files are included, so the contents vary depending on what lives in the source workspace.
 
-The `runtime/` subtree is only present when `--runtime-mode default` or `--runtime-mode full` is used on export. Its `manifest.json` records the mode, source agentDir, and which files were included or excluded. The `files/` subdirectory contains the actual runtime files.
+The `runtime/` subtree is only present when `--runtime-mode default` or `--runtime-mode full` is used on export. Its `manifest.json` records the mode, source agentDir, the `grounded` / `inferred` / `unsupported` classification, and which files were included or excluded. The `files/` subdirectory contains only the runtime files that the selected mode is allowed to package.
 
 Packages can also be distributed as single-file `.ocpkg.tar.gz` archives.
 
@@ -505,16 +520,16 @@ Packages can also be distributed as single-file `.ocpkg.tar.gz` archives.
 
 Near-term likely improvements:
 
-- richer import guidance when models or skills are missing
+- richer import guidance when models or inferred runtime files are missing
 - better package compatibility/version negotiation
 
 Current limitations to be aware of:
 
 - package format should still be treated as early-stage (currently v2)
-- skills are detected and optionally bundled via `--runtime-mode full`, but not auto-installed on import
+- skills are detected in workspace content, but runtime `skills/**` and `extensions/**` are currently classified as unsupported and are not bundled
 - `--force` uses file-level replacement semantics — only files present in the package are overwritten; unrelated files in the target workspace are preserved
 - OpenClaw config support is minimal by design
-- runtime layer path rewriting only handles `settings.json` — other config files with embedded paths require manual update
+- runtime layer path rewriting only handles inferred `settings.json` — other config files with embedded paths require manual update
 
 ## Development
 

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -82,6 +82,9 @@ export async function runExport(options: ExportOptions): Promise<void> {
     fileCount: result.fileCount,
     runtimeMode: runtimeScan?.mode,
     runtimeFiles: runtimeScan?.includedFiles.map(f => f.relativePath),
+    runtimeGroundedFiles: runtimeScan?.artifacts.grounded,
+    runtimeInferredFiles: runtimeScan?.artifacts.inferred,
+    runtimeUnsupportedFiles: runtimeScan?.artifacts.unsupported,
   };
 
   if (options.json) {
@@ -96,8 +99,12 @@ export async function runExport(options: ExportOptions): Promise<void> {
     `  Files: ${report.fileCount}`,
   ];
   if (runtimeScan && runtimeScan.mode !== 'none') {
+    lines.push('  Runtime contract: grounded=source-backed, inferred=convenience-only, unsupported=not packaged');
     lines.push(`  Runtime mode: ${runtimeScan.mode}`);
     lines.push(`  Runtime files: ${runtimeScan.includedFiles.length}`);
+    lines.push(`  Runtime grounded files: ${runtimeScan.artifacts.grounded.length}`);
+    lines.push(`  Runtime inferred files: ${runtimeScan.artifacts.inferred.length}`);
+    lines.push(`  Runtime unsupported files: ${runtimeScan.artifacts.unsupported.length}`);
   }
   console.log(lines.join('\n'));
 }
@@ -112,7 +119,7 @@ export function registerExportCommand(command: Command): void {
     .option('--agent-id <id>', 'Source agent id override')
     .option(
       '--runtime-mode <mode>',
-      'Runtime layer mode: none (skip), default (settings, prompts, themes, models), or full (adds skills, extensions). Requires a resolvable agentDir in OpenClaw config. Auth and session files are always excluded.',
+      'Runtime layer mode: none (skip), default (grounded source-backed runtime artifacts only), or full (adds inferred convenience files). Unsupported skills/extensions are never packaged. Requires a resolvable agentDir in OpenClaw config. Auth and session files are always excluded.',
     )
     .option('--archive', 'Produce a .ocpkg.tar.gz single-file archive')
     .option('--json', 'Emit the full machine-readable JSON report')

--- a/src/commands/inspect.ts
+++ b/src/commands/inspect.ts
@@ -75,6 +75,7 @@ export async function runInspect(options: InspectOptions): Promise<void> {
       agentDir: runtimeResult.agentDir,
       includedFiles: runtimeResult.includedFiles.map(f => f.relativePath),
       excludedFiles: runtimeResult.excludedFiles,
+      artifacts: runtimeResult.artifacts,
       warnings: runtimeResult.warnings,
     } : undefined,
     warnings,
@@ -113,8 +114,12 @@ export async function runInspect(options: InspectOptions): Promise<void> {
   }
 
   if (runtimeResult) {
+    lines.push('Runtime contract: grounded=source-backed, inferred=convenience-only, unsupported=not packaged');
     lines.push(`Runtime agentDir: ${runtimeResult.agentDir}`);
     lines.push(`Runtime included files (${runtimeResult.includedFiles.length}): ${runtimeResult.includedFiles.map(f => f.relativePath).join(', ') || 'none'}`);
+    lines.push(`Runtime grounded files (${runtimeResult.artifacts.grounded.length}): ${runtimeResult.artifacts.grounded.join(', ') || 'none'}`);
+    lines.push(`Runtime inferred files (${runtimeResult.artifacts.inferred.length}): ${runtimeResult.artifacts.inferred.join(', ') || 'none'}`);
+    lines.push(`Runtime unsupported files (${runtimeResult.artifacts.unsupported.length}): ${runtimeResult.artifacts.unsupported.join(', ') || 'none'}`);
     lines.push(`Runtime excluded files (${runtimeResult.excludedFiles.length}): ${runtimeResult.excludedFiles.map(f => `${f.relativePath} [${f.reason}]`).join(', ') || 'none'}`);
     if (runtimeResult.warnings.length > 0) {
       lines.push(`Runtime warnings: ${runtimeResult.warnings.join(' | ')}`);
@@ -132,7 +137,7 @@ export function registerInspectCommand(command: Command): void {
     .option('--agent-id <id>', 'Source agent id override')
     .option(
       '--runtime-mode <mode>',
-      'Runtime layer mode: none (skip), default (settings, prompts, themes, models), or full (adds skills, extensions). Defaults to "default" when omitted. Auth and session files are always excluded.',
+      'Runtime layer mode: none (skip), default (grounded source-backed runtime artifacts only), or full (adds inferred convenience files). Unsupported skills/extensions are never packaged. Defaults to "default" when omitted. Auth and session files are always excluded.',
     )
     .option('--json', 'Emit the full machine-readable JSON report')
     .action(runInspect);

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -51,15 +51,17 @@ export const SKILL_REFERENCE_PATTERNS = [
   /<name>([a-z0-9][a-z0-9-]*)<\/name>/gi,
 ];
 
-export const RUNTIME_ALLOWLIST_DEFAULT: string[] = [
-  'AGENTS.md',
-  'settings.json',
-  'prompts/**',
-  'themes/**',
+export const RUNTIME_GROUNDED_ARTIFACTS: string[] = [
   'models.json',
 ];
 
-export const RUNTIME_ALLOWLIST_FULL_EXTRA: string[] = [
+export const RUNTIME_INFERRED_ARTIFACTS: string[] = [
+  'settings.json',
+  'prompts/**',
+  'themes/**',
+];
+
+export const RUNTIME_UNSUPPORTED_ARTIFACTS: string[] = [
   'skills/**',
   'extensions/**',
 ];

--- a/src/core/import-plan.ts
+++ b/src/core/import-plan.ts
@@ -338,7 +338,7 @@ async function planRuntimeImport(params: {
 
   if (runtimeFiles.length > 0) {
     nextSteps.push(
-      'Review runtime files (settings.json, prompts, themes) in the target agentDir after import.',
+      'Review imported runtime files in the target agentDir after import, especially any inferred convenience files.',
     );
   }
 

--- a/src/core/package-write.ts
+++ b/src/core/package-write.ts
@@ -154,6 +154,7 @@ export async function writePackageDirectory(params: {
       agentDir: runtimeScan.agentDir,
       includedFiles: runtimeScan.includedFiles.map(f => f.relativePath),
       excludedFiles: runtimeScan.excludedFiles,
+      artifacts: runtimeScan.artifacts,
       warnings: runtimeScan.warnings,
       modelsSanitized: runtimeScan.sanitizedModels !== undefined,
       modelsSkipped: runtimeScan.sanitizedModels === undefined &&

--- a/src/core/runtime-scan.ts
+++ b/src/core/runtime-scan.ts
@@ -1,14 +1,21 @@
 import { lstat, readFile, readdir } from 'node:fs/promises';
 import path from 'node:path';
 import {
-  RUNTIME_ALLOWLIST_DEFAULT,
-  RUNTIME_ALLOWLIST_FULL_EXTRA,
+  RUNTIME_GROUNDED_ARTIFACTS,
+  RUNTIME_INFERRED_ARTIFACTS,
+  RUNTIME_UNSUPPORTED_ARTIFACTS,
   RUNTIME_ALWAYS_EXCLUDE,
   RUNTIME_EXCLUDE_EXTENSIONS,
 } from './constants';
 import { sanitizeModelsJson } from './models-sanitize';
 import { analyzeSettingsJson } from './settings-analysis';
-import type { ExcludedWorkspaceFile, RuntimeMode, RuntimeScanResult, SettingsAnalysis } from './types';
+import type {
+  ExcludedWorkspaceFile,
+  RuntimeArtifactBuckets,
+  RuntimeMode,
+  RuntimeScanResult,
+  SettingsAnalysis,
+} from './types';
 
 export async function scanRuntime(params: {
   mode: RuntimeMode;
@@ -23,6 +30,7 @@ export async function scanRuntime(params: {
       agentDir,
       includedFiles: [],
       excludedFiles: [],
+      artifacts: emptyRuntimeArtifacts(),
       warnings: [],
       sanitizedModels: undefined,
       settingsAnalysis: undefined,
@@ -36,18 +44,16 @@ export async function scanRuntime(params: {
       agentDir,
       includedFiles: [],
       excludedFiles: [],
+      artifacts: emptyRuntimeArtifacts(),
       warnings: [`agentDir does not exist or is not a directory: ${agentDir}`],
       sanitizedModels: undefined,
       settingsAnalysis: undefined,
     };
   }
 
-  const allowlist = mode === 'full'
-    ? [...RUNTIME_ALLOWLIST_DEFAULT, ...RUNTIME_ALLOWLIST_FULL_EXTRA]
-    : [...RUNTIME_ALLOWLIST_DEFAULT];
-
   const includedFiles: Array<{ relativePath: string; absolutePath: string }> = [];
   const excludedFiles: ExcludedWorkspaceFile[] = [];
+  const artifacts: RuntimeArtifactBuckets = emptyRuntimeArtifacts();
   const warnings: string[] = [];
   const allFiles = await collectFiles(agentDir, '', warnings);
 
@@ -68,19 +74,29 @@ export async function scanRuntime(params: {
       continue;
     }
 
-    if (matchesAllowlist(relativePath, allowlist)) {
-      includedFiles.push({ relativePath, absolutePath });
+    const evidence = classifyRuntimeArtifact(relativePath);
+    if (!evidence) {
       continue;
     }
 
-    if (mode !== 'full' && matchesAllowlist(relativePath, RUNTIME_ALLOWLIST_FULL_EXTRA)) {
-      excludedFiles.push({ relativePath, reason: 'Excluded: requires full mode' });
+    artifacts[evidence].push(relativePath);
+
+    if (evidence === 'unsupported') {
+      excludedFiles.push({ relativePath, reason: 'Excluded: unsupported runtime artifact' });
+      continue;
+    }
+
+    if (shouldIncludeForMode(mode, evidence)) {
+      includedFiles.push({ relativePath, absolutePath });
+    } else {
+      excludedFiles.push({ relativePath, reason: 'Excluded: inferred runtime artifact (requires full mode)' });
     }
   }
 
   let sanitizedModels: Record<string, unknown> | undefined;
   const modelsPath = path.join(agentDir, 'models.json');
-  if (allFiles.includes('models.json') && matchesAllowlist('models.json', allowlist)) {
+  if (allFiles.includes('models.json')) {
+    artifacts.grounded.push('models.json');
     try {
       const raw = await readFile(modelsPath, 'utf8');
       const parsed = JSON.parse(raw);
@@ -113,8 +129,9 @@ export async function scanRuntime(params: {
   return {
     mode,
     agentDir,
-    includedFiles,
-    excludedFiles,
+    includedFiles: includedFiles.sort((left, right) => left.relativePath.localeCompare(right.relativePath)),
+    excludedFiles: excludedFiles.sort((left, right) => left.relativePath.localeCompare(right.relativePath)),
+    artifacts: sortRuntimeArtifacts(artifacts),
     warnings,
     sanitizedModels,
     settingsAnalysis,
@@ -169,6 +186,26 @@ function matchesAllowlist(relativePath: string, allowlist: string[]): boolean {
   return false;
 }
 
+function classifyRuntimeArtifact(relativePath: string): keyof RuntimeArtifactBuckets | undefined {
+  if (matchesAllowlist(relativePath, RUNTIME_GROUNDED_ARTIFACTS)) {
+    return 'grounded';
+  }
+  if (matchesAllowlist(relativePath, RUNTIME_INFERRED_ARTIFACTS)) {
+    return 'inferred';
+  }
+  if (matchesAllowlist(relativePath, RUNTIME_UNSUPPORTED_ARTIFACTS)) {
+    return 'unsupported';
+  }
+  return undefined;
+}
+
+function shouldIncludeForMode(mode: RuntimeMode, evidence: Exclude<keyof RuntimeArtifactBuckets, 'unsupported'>): boolean {
+  if (mode === 'full') {
+    return true;
+  }
+  return evidence === 'grounded';
+}
+
 function isAlwaysExcluded(relativePath: string): boolean {
   for (const pattern of RUNTIME_ALWAYS_EXCLUDE) {
     if (pattern.endsWith('/**')) {
@@ -193,4 +230,20 @@ async function isDirectory(dirPath: string): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+function emptyRuntimeArtifacts(): RuntimeArtifactBuckets {
+  return {
+    grounded: [],
+    inferred: [],
+    unsupported: [],
+  };
+}
+
+function sortRuntimeArtifacts(artifacts: RuntimeArtifactBuckets): RuntimeArtifactBuckets {
+  return {
+    grounded: [...artifacts.grounded].sort((left, right) => left.localeCompare(right)),
+    inferred: [...artifacts.inferred].sort((left, right) => left.localeCompare(right)),
+    unsupported: [...artifacts.unsupported].sort((left, right) => left.localeCompare(right)),
+  };
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -273,11 +273,18 @@ export interface ValidationReport {
 
 export type RuntimeMode = 'none' | 'default' | 'full';
 
+export interface RuntimeArtifactBuckets {
+  grounded: string[];
+  inferred: string[];
+  unsupported: string[];
+}
+
 export interface RuntimeScanResult {
   mode: RuntimeMode;
   agentDir: string;
   includedFiles: Array<{ relativePath: string; absolutePath: string }>;
   excludedFiles: ExcludedWorkspaceFile[];
+  artifacts: RuntimeArtifactBuckets;
   warnings: string[];
   sanitizedModels: Record<string, unknown> | undefined;
   settingsAnalysis: SettingsAnalysis | undefined;
@@ -288,6 +295,7 @@ export interface RuntimeManifest {
   agentDir: string;
   includedFiles: string[];
   excludedFiles: ExcludedWorkspaceFile[];
+  artifacts: RuntimeArtifactBuckets;
   warnings: string[];
   modelsSanitized: boolean;
   modelsSkipped: boolean;

--- a/tests/helpers/runtime-package-factory.ts
+++ b/tests/helpers/runtime-package-factory.ts
@@ -66,6 +66,11 @@ export async function buildRuntimeTestPackage(
     agentDir: options.sourceAgentDir,
     includedFiles: mode === 'none' ? [] : includedFiles,
     excludedFiles: [],
+    artifacts: {
+      grounded: [],
+      inferred: mode === 'none' ? [] : includedFiles,
+      unsupported: [],
+    },
     warnings: [],
     modelsSanitized: false,
     modelsSkipped: true,

--- a/tests/helpers/runtime-package-factory.ts
+++ b/tests/helpers/runtime-package-factory.ts
@@ -1,9 +1,15 @@
 import { mkdir, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { checksumText } from '../../src/core/checksums';
+import {
+  RUNTIME_GROUNDED_ARTIFACTS,
+  RUNTIME_INFERRED_ARTIFACTS,
+  RUNTIME_UNSUPPORTED_ARTIFACTS,
+} from '../../src/core/constants';
 import { readPackageDirectory } from '../../src/core/package-read';
 import type {
   ReadPackageResult,
+  RuntimeArtifactBuckets,
   RuntimeManifest,
   RuntimeMode,
   SettingsAnalysis,
@@ -16,6 +22,7 @@ interface RuntimePackageOptions {
   packageName?: string;
   runtimeMode?: RuntimeMode;
   settingsAnalysis?: SettingsAnalysis;
+  artifacts?: RuntimeArtifactBuckets;
 }
 
 /**
@@ -61,16 +68,14 @@ export async function buildRuntimeTestPackage(
     includedFiles.push(relPath);
   }
 
+  const artifacts = options.artifacts ?? classifyRuntimeArtifacts(mode === 'none' ? [] : includedFiles);
+
   const runtimeManifest: RuntimeManifest = {
     mode,
     agentDir: options.sourceAgentDir,
     includedFiles: mode === 'none' ? [] : includedFiles,
     excludedFiles: [],
-    artifacts: {
-      grounded: [],
-      inferred: mode === 'none' ? [] : includedFiles,
-      unsupported: [],
-    },
+    artifacts,
     warnings: [],
     modelsSanitized: false,
     modelsSkipped: true,
@@ -190,4 +195,50 @@ export async function buildRuntimeTestPackage(
   await writeFile(path.join(outputPath, 'manifest.json'), `${manifestJson}\n`, 'utf8');
 
   return readPackageDirectory(outputPath);
+}
+
+function classifyRuntimeArtifacts(includedFiles: string[]): RuntimeArtifactBuckets {
+  const artifacts: RuntimeArtifactBuckets = {
+    grounded: [],
+    inferred: [],
+    unsupported: [],
+  };
+
+  for (const relativePath of includedFiles) {
+    if (matchesPattern(relativePath, RUNTIME_GROUNDED_ARTIFACTS)) {
+      artifacts.grounded.push(relativePath);
+      continue;
+    }
+    if (matchesPattern(relativePath, RUNTIME_INFERRED_ARTIFACTS)) {
+      artifacts.inferred.push(relativePath);
+      continue;
+    }
+    if (matchesPattern(relativePath, RUNTIME_UNSUPPORTED_ARTIFACTS)) {
+      artifacts.unsupported.push(relativePath);
+    }
+  }
+
+  return {
+    grounded: artifacts.grounded.sort((left, right) => left.localeCompare(right)),
+    inferred: artifacts.inferred.sort((left, right) => left.localeCompare(right)),
+    unsupported: artifacts.unsupported.sort((left, right) => left.localeCompare(right)),
+  };
+}
+
+function matchesPattern(relativePath: string, patterns: string[]): boolean {
+  for (const pattern of patterns) {
+    if (pattern.endsWith('/**')) {
+      const prefix = pattern.slice(0, -3);
+      if (relativePath.startsWith(`${prefix}/`)) {
+        return true;
+      }
+      continue;
+    }
+
+    if (pattern === relativePath) {
+      return true;
+    }
+  }
+
+  return false;
 }

--- a/tests/runtime-constants.test.ts
+++ b/tests/runtime-constants.test.ts
@@ -1,23 +1,28 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
-  RUNTIME_ALLOWLIST_DEFAULT,
-  RUNTIME_ALLOWLIST_FULL_EXTRA,
+  RUNTIME_GROUNDED_ARTIFACTS,
+  RUNTIME_INFERRED_ARTIFACTS,
+  RUNTIME_UNSUPPORTED_ARTIFACTS,
   RUNTIME_ALWAYS_EXCLUDE,
   RUNTIME_EXCLUDE_EXTENSIONS,
 } from '../src/core/constants';
 
-test('RUNTIME_ALLOWLIST_DEFAULT includes expected files', () => {
-  assert.ok(RUNTIME_ALLOWLIST_DEFAULT.some((p) => p === 'AGENTS.md'));
-  assert.ok(RUNTIME_ALLOWLIST_DEFAULT.some((p) => p === 'settings.json'));
-  assert.ok(RUNTIME_ALLOWLIST_DEFAULT.some((p) => p === 'prompts/**'));
-  assert.ok(RUNTIME_ALLOWLIST_DEFAULT.some((p) => p === 'themes/**'));
-  assert.ok(RUNTIME_ALLOWLIST_DEFAULT.some((p) => p === 'models.json'));
+test('RUNTIME_GROUNDED_ARTIFACTS includes only source-backed runtime files', () => {
+  assert.ok(RUNTIME_GROUNDED_ARTIFACTS.some((p) => p === 'models.json'));
+  assert.equal(RUNTIME_GROUNDED_ARTIFACTS.includes('settings.json'), false);
+  assert.equal(RUNTIME_GROUNDED_ARTIFACTS.includes('AGENTS.md'), false);
 });
 
-test('RUNTIME_ALLOWLIST_FULL_EXTRA adds skills and extensions', () => {
-  assert.ok(RUNTIME_ALLOWLIST_FULL_EXTRA.some((p) => p === 'skills/**'));
-  assert.ok(RUNTIME_ALLOWLIST_FULL_EXTRA.some((p) => p === 'extensions/**'));
+test('RUNTIME_INFERRED_ARTIFACTS contains convenience-only runtime files', () => {
+  assert.ok(RUNTIME_INFERRED_ARTIFACTS.some((p) => p === 'settings.json'));
+  assert.ok(RUNTIME_INFERRED_ARTIFACTS.some((p) => p === 'prompts/**'));
+  assert.ok(RUNTIME_INFERRED_ARTIFACTS.some((p) => p === 'themes/**'));
+});
+
+test('RUNTIME_UNSUPPORTED_ARTIFACTS contains non-portable capability directories', () => {
+  assert.ok(RUNTIME_UNSUPPORTED_ARTIFACTS.some((p) => p === 'skills/**'));
+  assert.ok(RUNTIME_UNSUPPORTED_ARTIFACTS.some((p) => p === 'extensions/**'));
 });
 
 test('RUNTIME_ALWAYS_EXCLUDE includes auth and session files', () => {

--- a/tests/runtime-import.test.ts
+++ b/tests/runtime-import.test.ts
@@ -54,6 +54,28 @@ test('Runtime import writes files under target agentDir', async () => {
   assert.ok(await pathExists(path.join(targetAgentDir, 'prompts/default.md')));
 });
 
+test('Runtime package test factory classifies manifest artifacts by evidence level', async () => {
+  const dir = 'factory-artifacts';
+  await cleanup(dir);
+  const pkgRoot = path.join(tmpBase, dir, 'fixture.ocpkg');
+
+  const pkg = await buildRuntimeTestPackage(pkgRoot, {
+    runtimeFiles: {
+      'models.json': JSON.stringify({ models: [{ id: 'gpt-5' }] }),
+      'settings.json': '{}',
+      'themes/dark.json': '{}',
+      'skills/demo/SKILL.md': '# demo\n',
+      'extensions/ext/package.json': '{}',
+    },
+    sourceAgentDir: '/source/agent-dir',
+    sourceWorkspacePath: '/source/workspace',
+  });
+
+  assert.deepEqual(pkg.runtimeManifest?.artifacts.grounded, ['models.json']);
+  assert.deepEqual(pkg.runtimeManifest?.artifacts.inferred, ['settings.json', 'themes/dark.json']);
+  assert.deepEqual(pkg.runtimeManifest?.artifacts.unsupported, ['extensions/ext/package.json', 'skills/demo/SKILL.md']);
+});
+
 test('Runtime import blocks on existing files without --force', async () => {
   const dir = 'collision-block';
   await cleanup(dir);

--- a/tests/runtime-inspect-export.test.ts
+++ b/tests/runtime-inspect-export.test.ts
@@ -13,6 +13,7 @@ test('inspect --runtime-mode default shows runtime section in human output', asy
   const agentDir = path.join(tmpBase, 'inspect-agentdir');
   await rm(agentDir, { recursive: true, force: true });
   await mkdir(agentDir, { recursive: true });
+  await writeFile(path.join(agentDir, 'models.json'), '{"models":[{"id":"gpt-5","apiKey":"sk-xxx"}]}', 'utf8');
   await writeFile(path.join(agentDir, 'settings.json'), '{}', 'utf8');
 
   const configPath = path.join(tmpBase, 'inspect-config.json');
@@ -36,7 +37,11 @@ test('inspect --runtime-mode default shows runtime section in human output', asy
     '--runtime-mode', 'default',
   ]);
   assert.match(stdout, /Runtime mode: default/);
+  assert.match(stdout, /Runtime grounded files/i);
+  assert.match(stdout, /models\.json/);
+  assert.match(stdout, /Runtime inferred files/i);
   assert.match(stdout, /settings\.json/);
+  assert.doesNotMatch(stdout, /Runtime grounded files .*AGENTS\.md/i);
 });
 
 test('inspect --runtime-mode default --json includes runtime data', async () => {
@@ -44,6 +49,7 @@ test('inspect --runtime-mode default --json includes runtime data', async () => 
   const agentDir = path.join(tmpBase, 'inspect-agentdir-json');
   await rm(agentDir, { recursive: true, force: true });
   await mkdir(agentDir, { recursive: true });
+  await writeFile(path.join(agentDir, 'models.json'), '{"models":[{"id":"gpt-5","apiKey":"sk-xxx"}]}', 'utf8');
   await writeFile(path.join(agentDir, 'settings.json'), '{}', 'utf8');
 
   const configPath = path.join(tmpBase, 'inspect-config-json.json');
@@ -70,6 +76,8 @@ test('inspect --runtime-mode default --json includes runtime data', async () => 
   const report = JSON.parse(stdout);
   assert.equal(report.runtime.mode, 'default');
   assert.ok(Array.isArray(report.runtime.includedFiles));
+  assert.ok(Array.isArray(report.runtime.artifacts.grounded));
+  assert.ok(report.runtime.artifacts.inferred.includes('settings.json'));
 });
 
 test('inspect without --runtime-mode defaults to resolved runtime mode output', async () => {
@@ -99,11 +107,12 @@ test('inspect --runtime-mode default warns when agentDir unresolvable', async ()
   assert.match(stdout, /[Cc]ould not resolve|agentDir/);
 });
 
-test('export --runtime-mode default writes runtime subtree in package', async () => {
+test('export --runtime-mode default writes only grounded runtime files in package', async () => {
   const wsPath = await createTempWorkspace(path.join(tmpBase, 'export-ws'));
   const agentDir = path.join(tmpBase, 'export-agentdir');
   await rm(agentDir, { recursive: true, force: true });
   await mkdir(agentDir, { recursive: true });
+  await writeFile(path.join(agentDir, 'models.json'), '{"models":[{"id":"gpt-5","apiKey":"sk-xxx"}]}', 'utf8');
   await writeFile(path.join(agentDir, 'settings.json'), '{}', 'utf8');
   await mkdir(path.join(agentDir, 'prompts'), { recursive: true });
   await writeFile(path.join(agentDir, 'prompts', 'system.md'), '# System', 'utf8');
@@ -135,7 +144,9 @@ test('export --runtime-mode default writes runtime subtree in package', async ()
 
   assert.match(stdout, /Export complete/);
   assert.ok(existsSync(path.join(outputPath, 'runtime', 'manifest.json')));
-  assert.ok(existsSync(path.join(outputPath, 'runtime', 'files', 'settings.json')));
+  assert.ok(existsSync(path.join(outputPath, 'runtime', 'files', 'models.json')));
+  assert.equal(existsSync(path.join(outputPath, 'runtime', 'files', 'settings.json')), false);
+  assert.equal(existsSync(path.join(outputPath, 'runtime', 'files', 'prompts', 'system.md')), false);
 });
 
 test('export --runtime-mode none does not write runtime subtree', async () => {
@@ -159,6 +170,7 @@ test('export --runtime-mode default --json includes runtime in report', async ()
   const agentDir = path.join(tmpBase, 'export-agentdir-json');
   await rm(agentDir, { recursive: true, force: true });
   await mkdir(agentDir, { recursive: true });
+  await writeFile(path.join(agentDir, 'models.json'), '{"models":[{"id":"gpt-5","apiKey":"sk-xxx"}]}', 'utf8');
   await writeFile(path.join(agentDir, 'settings.json'), '{}', 'utf8');
 
   const configPath = path.join(tmpBase, 'export-config-json.json');
@@ -190,6 +202,8 @@ test('export --runtime-mode default --json includes runtime in report', async ()
   const report = JSON.parse(stdout);
   assert.equal(report.status, 'ok');
   assert.equal(report.runtimeMode, 'default');
+  assert.ok(report.runtimeGroundedFiles.includes('models.json'));
+  assert.ok(report.runtimeInferredFiles.includes('settings.json'));
 });
 
 test('export --archive --json reports an existing manifestPath', async () => {
@@ -213,12 +227,15 @@ test('export --archive --json reports an existing manifestPath', async () => {
   assert.equal(existsSync(report.manifestPath), true);
 });
 
-test('export --runtime-mode full includes skills and extensions in runtime subtree', async () => {
+test('export --runtime-mode full includes inferred files but still excludes unsupported skills and extensions', async () => {
   const wsPath = await createTempWorkspace(path.join(tmpBase, 'export-ws-full'));
   const agentDir = path.join(tmpBase, 'export-agentdir-full');
   await rm(agentDir, { recursive: true, force: true });
   await mkdir(agentDir, { recursive: true });
+  await writeFile(path.join(agentDir, 'models.json'), '{"models":[{"id":"gpt-5","apiKey":"sk-xxx"}]}', 'utf8');
   await writeFile(path.join(agentDir, 'settings.json'), '{}', 'utf8');
+  await mkdir(path.join(agentDir, 'prompts'), { recursive: true });
+  await writeFile(path.join(agentDir, 'prompts', 'system.md'), '# System', 'utf8');
   await mkdir(path.join(agentDir, 'skills', 'my-skill'), { recursive: true });
   await writeFile(path.join(agentDir, 'skills', 'my-skill', 'SKILL.md'), '# My Skill', 'utf8');
   await mkdir(path.join(agentDir, 'extensions', 'ext1'), { recursive: true });
@@ -253,12 +270,18 @@ test('export --runtime-mode full includes skills and extensions in runtime subtr
   const report = JSON.parse(stdout);
   assert.equal(report.status, 'ok');
   assert.equal(report.runtimeMode, 'full');
-  assert.ok(report.runtimeFiles.some((f: string) => f.includes('skills/')));
-  assert.ok(report.runtimeFiles.some((f: string) => f.includes('extensions/')));
+  assert.ok(report.runtimeFiles.includes('settings.json'));
+  assert.ok(report.runtimeFiles.includes('prompts/system.md'));
+  assert.ok(!report.runtimeFiles.some((f: string) => f.includes('skills/')));
+  assert.ok(!report.runtimeFiles.some((f: string) => f.includes('extensions/')));
+  assert.ok(report.runtimeUnsupportedFiles.includes('skills/my-skill/SKILL.md'));
+  assert.ok(report.runtimeUnsupportedFiles.includes('extensions/ext1/package.json'));
 
   assert.ok(existsSync(path.join(outputPath, 'runtime', 'manifest.json')));
-  assert.ok(existsSync(path.join(outputPath, 'runtime', 'files', 'skills', 'my-skill', 'SKILL.md')));
-  assert.ok(existsSync(path.join(outputPath, 'runtime', 'files', 'extensions', 'ext1', 'package.json')));
+  assert.ok(existsSync(path.join(outputPath, 'runtime', 'files', 'settings.json')));
+  assert.ok(existsSync(path.join(outputPath, 'runtime', 'files', 'prompts', 'system.md')));
+  assert.equal(existsSync(path.join(outputPath, 'runtime', 'files', 'skills', 'my-skill', 'SKILL.md')), false);
+  assert.equal(existsSync(path.join(outputPath, 'runtime', 'files', 'extensions', 'ext1', 'package.json')), false);
 });
 
 test('export --runtime-mode default excludes skills and extensions', async () => {

--- a/tests/runtime-package.test.ts
+++ b/tests/runtime-package.test.ts
@@ -13,11 +13,16 @@ import { createTempWorkspace } from './helpers/workspace-factory';
 
 const tmpBase = path.resolve('tests/tmp/runtime-pkg');
 
-test('writePackageDirectory writes runtime subtree when runtimeScan provided', async () => {
+test('writePackageDirectory writes grounded runtime subtree for default mode', async () => {
   const wsPath = await createTempWorkspace(path.join(tmpBase, 'ws'));
   const agentDir = path.join(tmpBase, 'agentdir');
   await rm(agentDir, { recursive: true, force: true });
   await mkdir(agentDir, { recursive: true });
+  await writeFile(
+    path.join(agentDir, 'models.json'),
+    JSON.stringify({ models: [{ id: 'gpt-5', apiKey: 'sk-xxx', maxTokens: 4096 }] }),
+    'utf8',
+  );
   await writeFile(path.join(agentDir, 'settings.json'), '{"theme":"dark"}', 'utf8');
   await writeFile(path.join(agentDir, 'AGENTS.md'), '# Agents', 'utf8');
   await mkdir(path.join(agentDir, 'prompts'), { recursive: true });
@@ -42,15 +47,17 @@ test('writePackageDirectory writes runtime subtree when runtimeScan provided', a
   assert.ok(existsSync(path.join(outputPath, 'runtime', 'manifest.json')));
   assert.ok(existsSync(path.join(outputPath, 'runtime', 'checksums.json')));
   assert.ok(existsSync(path.join(outputPath, 'runtime', 'path-rewrites.json')));
-  assert.ok(existsSync(path.join(outputPath, 'runtime', 'files', 'settings.json')));
-  assert.ok(existsSync(path.join(outputPath, 'runtime', 'files', 'AGENTS.md')));
-  assert.ok(existsSync(path.join(outputPath, 'runtime', 'files', 'prompts', 'system.md')));
+  assert.ok(existsSync(path.join(outputPath, 'runtime', 'files', 'models.json')));
+  assert.equal(existsSync(path.join(outputPath, 'runtime', 'files', 'AGENTS.md')), false);
+  assert.equal(existsSync(path.join(outputPath, 'runtime', 'files', 'settings.json')), false);
+  assert.equal(existsSync(path.join(outputPath, 'runtime', 'files', 'prompts', 'system.md')), false);
 
   const runtimeManifest = JSON.parse(
     await readFile(path.join(outputPath, 'runtime', 'manifest.json'), 'utf8'),
   );
   assert.equal(runtimeManifest.mode, 'default');
-  assert.ok(runtimeManifest.includedFiles.includes('settings.json'));
+  assert.deepEqual(runtimeManifest.artifacts.grounded, ['models.json']);
+  assert.ok(runtimeManifest.artifacts.inferred.includes('settings.json'));
 });
 
 test('writePackageDirectory omits runtime subtree when no runtimeScan', async () => {
@@ -72,7 +79,7 @@ test('writePackageDirectory omits runtime subtree when no runtimeScan', async ()
   assert.equal(existsSync(path.join(outputPath, 'runtime')), false);
 });
 
-test('writePackageDirectory includes settings-analysis.json when analysis exists', async () => {
+test('writePackageDirectory includes settings-analysis.json when full mode includes inferred settings.json', async () => {
   const wsPath = await createTempWorkspace(path.join(tmpBase, 'ws-sa'));
   const agentDir = path.join(tmpBase, 'agentdir-sa');
   await rm(agentDir, { recursive: true, force: true });
@@ -86,7 +93,7 @@ test('writePackageDirectory includes settings-analysis.json when analysis exists
   const scan = await scanWorkspace(wsPath);
   const skills = await detectSkills(scan);
   const agent = await extractAgentDefinition(wsPath);
-  const runtimeScan = await scanRuntime({ mode: 'default', agentDir, workspacePath: wsPath });
+  const runtimeScan = await scanRuntime({ mode: 'full', agentDir, workspacePath: wsPath });
 
   const outputPath = path.join(tmpBase, 'output-sa.ocpkg');
   await rm(outputPath, { recursive: true, force: true });
@@ -161,6 +168,11 @@ test('writePackageDirectory preserves runtime warnings even when no runtime file
       agentDir: '/tmp/runtime-agent',
       includedFiles: [],
       excludedFiles: [],
+      artifacts: {
+        grounded: [],
+        inferred: [],
+        unsupported: [],
+      },
       warnings: ['models.json contained only secrets — skipped entirely.'],
       sanitizedModels: undefined,
       settingsAnalysis: undefined,
@@ -187,7 +199,7 @@ test('manifest.includes.runtimeMode reflects runtime mode', async () => {
   const agentDir = path.join(tmpBase, 'agentdir-manifest');
   await rm(agentDir, { recursive: true, force: true });
   await mkdir(agentDir, { recursive: true });
-  await writeFile(path.join(agentDir, 'settings.json'), '{}', 'utf8');
+  await writeFile(path.join(agentDir, 'models.json'), '{"models":[{"id":"gpt-5","apiKey":"sk-xxx"}]}', 'utf8');
 
   const scan = await scanWorkspace(wsPath);
   const skills = await detectSkills(scan);
@@ -216,7 +228,7 @@ test('readPackageDirectory reads runtime subtree when present', async () => {
   const agentDir = path.join(tmpBase, 'agentdir-read');
   await rm(agentDir, { recursive: true, force: true });
   await mkdir(agentDir, { recursive: true });
-  await writeFile(path.join(agentDir, 'settings.json'), '{"theme":"light"}', 'utf8');
+  await writeFile(path.join(agentDir, 'models.json'), '{"models":[{"id":"gpt-5","apiKey":"sk-xxx"}]}', 'utf8');
 
   const scan = await scanWorkspace(wsPath);
   const skills = await detectSkills(scan);
@@ -237,7 +249,7 @@ test('readPackageDirectory reads runtime subtree when present', async () => {
   const pkg = await readPackageDirectory(outputPath);
   assert.ok(pkg.runtimeManifest);
   assert.equal(pkg.runtimeManifest!.mode, 'default');
-  assert.ok(pkg.runtimeManifest!.includedFiles.includes('settings.json'));
+  assert.ok(pkg.runtimeManifest!.includedFiles.includes('models.json'));
 });
 
 test('readPackageDirectory tolerates packages without runtime subtree', async () => {

--- a/tests/runtime-scan.test.ts
+++ b/tests/runtime-scan.test.ts
@@ -25,32 +25,38 @@ test('scanRuntime mode=none returns empty results', async () => {
   assert.equal(result.excludedFiles.length, 0);
 });
 
-test('scanRuntime mode=default includes settings.json and AGENTS.md', async () => {
+test('scanRuntime mode=default includes grounded models.json only', async () => {
   const agentDir = await setupAgentDir({
     'AGENTS.md': '# Agents',
     'settings.json': '{}',
+    'models.json': JSON.stringify({ models: [{ id: 'gpt-5', apiKey: 'sk-xxx' }] }),
     'auth.json': '{ "token": "secret" }',
   });
   const result = await scanRuntime({ mode: 'default', agentDir, workspacePath: '/tmp/ws' });
   assert.equal(result.mode, 'default');
-  assert.ok(result.includedFiles.some(f => f.relativePath === 'AGENTS.md'));
-  assert.ok(result.includedFiles.some(f => f.relativePath === 'settings.json'));
+  assert.ok(result.includedFiles.some(f => f.relativePath === 'models.json'));
+  assert.ok(!result.includedFiles.some(f => f.relativePath === 'AGENTS.md'));
+  assert.ok(!result.includedFiles.some(f => f.relativePath === 'settings.json'));
+  assert.deepEqual(result.artifacts.grounded, ['models.json']);
+  assert.ok(result.artifacts.inferred.includes('settings.json'));
   assert.ok(result.excludedFiles.some(f => f.relativePath === 'auth.json'));
 });
 
-test('scanRuntime mode=default includes prompts/** and themes/**', async () => {
+test('scanRuntime mode=default excludes inferred prompts/** and themes/**', async () => {
   const agentDir = await setupAgentDir({
     'prompts/system.md': '# System prompt',
     'prompts/user.md': '# User prompt',
     'themes/dark.json': '{}',
   });
   const result = await scanRuntime({ mode: 'default', agentDir, workspacePath: '/tmp/ws' });
-  assert.ok(result.includedFiles.some(f => f.relativePath === 'prompts/system.md'));
-  assert.ok(result.includedFiles.some(f => f.relativePath === 'prompts/user.md'));
-  assert.ok(result.includedFiles.some(f => f.relativePath === 'themes/dark.json'));
+  assert.ok(!result.includedFiles.some(f => f.relativePath === 'prompts/system.md'));
+  assert.ok(!result.includedFiles.some(f => f.relativePath === 'prompts/user.md'));
+  assert.ok(!result.includedFiles.some(f => f.relativePath === 'themes/dark.json'));
+  assert.deepEqual(result.artifacts.inferred, ['prompts/system.md', 'prompts/user.md', 'themes/dark.json']);
+  assert.ok(result.excludedFiles.some(f => f.relativePath === 'prompts/system.md' && /inferred|full mode/i.test(f.reason)));
 });
 
-test('scanRuntime mode=default excludes skills/** and extensions/** with explicit reasons', async () => {
+test('scanRuntime mode=default excludes unsupported skills/** and extensions/** with explicit reasons', async () => {
   const agentDir = await setupAgentDir({
     'settings.json': '{}',
     'skills/my-skill/SKILL.md': '# Skill',
@@ -59,19 +65,26 @@ test('scanRuntime mode=default excludes skills/** and extensions/** with explici
   const result = await scanRuntime({ mode: 'default', agentDir, workspacePath: '/tmp/ws' });
   assert.ok(!result.includedFiles.some(f => f.relativePath.startsWith('skills/')));
   assert.ok(!result.includedFiles.some(f => f.relativePath.startsWith('extensions/')));
-  assert.ok(result.excludedFiles.some(f => f.relativePath === 'skills/my-skill/SKILL.md' && /full mode/i.test(f.reason)));
-  assert.ok(result.excludedFiles.some(f => f.relativePath === 'extensions/ext1/package.json' && /full mode/i.test(f.reason)));
+  assert.deepEqual(result.artifacts.unsupported, ['extensions/ext1/package.json', 'skills/my-skill/SKILL.md']);
+  assert.ok(result.excludedFiles.some(f => f.relativePath === 'skills/my-skill/SKILL.md' && /unsupported/i.test(f.reason)));
+  assert.ok(result.excludedFiles.some(f => f.relativePath === 'extensions/ext1/package.json' && /unsupported/i.test(f.reason)));
 });
 
-test('scanRuntime mode=full includes skills/** and extensions/**', async () => {
+test('scanRuntime mode=full includes inferred settings/prompts/themes but still excludes unsupported skills/extensions', async () => {
   const agentDir = await setupAgentDir({
     'settings.json': '{}',
+    'prompts/system.md': '# System',
+    'themes/dark.json': '{}',
     'skills/my-skill/SKILL.md': '# Skill',
     'extensions/ext1/package.json': '{}',
   });
   const result = await scanRuntime({ mode: 'full', agentDir, workspacePath: '/tmp/ws' });
-  assert.ok(result.includedFiles.some(f => f.relativePath === 'skills/my-skill/SKILL.md'));
-  assert.ok(result.includedFiles.some(f => f.relativePath === 'extensions/ext1/package.json'));
+  assert.ok(result.includedFiles.some(f => f.relativePath === 'settings.json'));
+  assert.ok(result.includedFiles.some(f => f.relativePath === 'prompts/system.md'));
+  assert.ok(result.includedFiles.some(f => f.relativePath === 'themes/dark.json'));
+  assert.ok(!result.includedFiles.some(f => f.relativePath === 'skills/my-skill/SKILL.md'));
+  assert.ok(!result.includedFiles.some(f => f.relativePath === 'extensions/ext1/package.json'));
+  assert.ok(result.excludedFiles.some(f => f.relativePath === 'skills/my-skill/SKILL.md' && /unsupported/i.test(f.reason)));
 });
 
 test('scanRuntime always excludes auth-profiles.json and sessions/**', async () => {
@@ -86,7 +99,7 @@ test('scanRuntime always excludes auth-profiles.json and sessions/**', async () 
   assert.ok(result.excludedFiles.some(f => f.relativePath === 'auth-profiles.json'));
 });
 
-test('scanRuntime sanitizes models.json and includes sanitized version', async () => {
+test('scanRuntime sanitizes grounded models.json and includes sanitized version in default mode', async () => {
   const agentDir = await setupAgentDir({
     'models.json': JSON.stringify({
       models: [{ id: 'gpt-4', provider: 'openai', apiKey: 'sk-xxx', maxTokens: 4096 }],
@@ -94,6 +107,7 @@ test('scanRuntime sanitizes models.json and includes sanitized version', async (
   });
   const result = await scanRuntime({ mode: 'default', agentDir, workspacePath: '/tmp/ws' });
   assert.ok(result.sanitizedModels);
+  assert.ok(result.includedFiles.some(f => f.relativePath === 'models.json'));
   assert.equal((result.sanitizedModels as any).models[0].apiKey, undefined);
   assert.equal((result.sanitizedModels as any).models[0].maxTokens, 4096);
 });
@@ -118,11 +132,11 @@ test('scanRuntime records excluded models.json when parsing fails', async () => 
   assert.ok(result.excludedFiles.some(f => f.relativePath === 'models.json' && /parse/i.test(f.reason)));
 });
 
-test('scanRuntime analyzes settings.json paths', async () => {
+test('scanRuntime analyzes settings.json paths when inferred files are included in full mode', async () => {
   const agentDir = await setupAgentDir({
     'settings.json': JSON.stringify({ 'data.path': '/usr/local/data' }),
   });
-  const result = await scanRuntime({ mode: 'default', agentDir, workspacePath: '/tmp/ws' });
+  const result = await scanRuntime({ mode: 'full', agentDir, workspacePath: '/tmp/ws' });
   assert.ok(result.settingsAnalysis);
   assert.equal(result.settingsAnalysis!.pathRefs.length, 1);
 });
@@ -171,7 +185,7 @@ test('scanRuntime reports directory read failures in warnings', async () => {
   await chmod(blockedDir, 0o000);
 
   try {
-    const result = await scanRuntime({ mode: 'default', agentDir, workspacePath: '/tmp/ws' });
+    const result = await scanRuntime({ mode: 'full', agentDir, workspacePath: '/tmp/ws' });
 
     assert.ok(result.includedFiles.some(f => f.relativePath === 'prompts/keep.md'));
     assert.ok(result.warnings.some(w => /blocked/.test(w)));
@@ -195,6 +209,7 @@ test('scanRuntime returns included files in deterministic sorted order', async (
   const agentDir = await setupAgentDir({
     'settings.json': '{}',
     'AGENTS.md': '# Agents',
+    'models.json': JSON.stringify({ models: [{ id: 'gpt-5', apiKey: 'sk-xxx' }] }),
     'prompts/z-last.md': '# Z',
     'prompts/a-first.md': '# A',
   });
@@ -203,7 +218,7 @@ test('scanRuntime returns included files in deterministic sorted order', async (
 
   assert.deepEqual(
     result.includedFiles.map(f => f.relativePath),
-    ['AGENTS.md', 'prompts/a-first.md', 'prompts/z-last.md', 'settings.json'],
+    ['models.json'],
   );
 });
 

--- a/tests/runtime-types.test.ts
+++ b/tests/runtime-types.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import type {
+  RuntimeArtifactBuckets,
   RuntimeManifest,
   RuntimeMode,
   RuntimeScanResult,
@@ -17,29 +18,51 @@ test('RuntimeManifest structure is valid', () => {
   const manifest: RuntimeManifest = {
     mode: 'default',
     agentDir: '/path/to/agentDir',
-    includedFiles: ['AGENTS.md', 'settings.json'],
+    includedFiles: ['models.json'],
     excludedFiles: [{ relativePath: 'auth.json', reason: 'Always excluded: secrets' }],
+    artifacts: {
+      grounded: ['models.json'],
+      inferred: ['settings.json'],
+      unsupported: ['skills/demo/SKILL.md'],
+    },
     warnings: [],
-    modelsSanitized: false,
+    modelsSanitized: true,
     modelsSkipped: false,
     settingsAnalysisIncluded: false,
   };
   assert.equal(manifest.mode, 'default');
-  assert.equal(manifest.includedFiles.length, 2);
+  assert.equal(manifest.includedFiles.length, 1);
+  assert.equal(manifest.artifacts.inferred.length, 1);
 });
 
 test('RuntimeScanResult structure is valid', () => {
   const result: RuntimeScanResult = {
     mode: 'default',
     agentDir: '/path/to/agentDir',
-    includedFiles: [{ relativePath: 'settings.json', absolutePath: '/abs/settings.json' }],
+    includedFiles: [{ relativePath: 'models.json', absolutePath: '/abs/models.json' }],
     excludedFiles: [{ relativePath: 'auth.json', reason: 'Always excluded: secrets' }],
+    artifacts: {
+      grounded: ['models.json'],
+      inferred: ['settings.json'],
+      unsupported: ['extensions/ext/package.json'],
+    },
     warnings: [],
-    sanitizedModels: undefined,
+    sanitizedModels: { models: [{ id: 'gpt-5' }] },
     settingsAnalysis: undefined,
   };
   assert.equal(result.mode, 'default');
   assert.equal(result.includedFiles.length, 1);
+  assert.equal(result.artifacts.grounded[0], 'models.json');
+});
+
+test('RuntimeArtifactBuckets groups runtime evidence levels', () => {
+  const buckets: RuntimeArtifactBuckets = {
+    grounded: ['models.json'],
+    inferred: ['settings.json'],
+    unsupported: ['skills/demo/SKILL.md'],
+  };
+  assert.equal(buckets.grounded.length, 1);
+  assert.equal(buckets.unsupported.length, 1);
 });
 
 test('SettingsAnalysis structure is valid', () => {


### PR DESCRIPTION
## Summary
- reclassify runtime agentDir contents into grounded, inferred, and unsupported buckets
- tighten `default` mode to source-backed runtime artifacts only and keep `full` from bundling unsupported `skills/**` and `extensions/**`
- update inspect/export output, package metadata, README, CHANGELOG, and runtime tests to match the new contract

## Testing
- `npm test`
- `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **New Features**
  * 运行时文件现按三类展示：基础（grounded）、推断（inferred）与不支持（unsupported），并在 inspect/export 输出中显示各类计数与清单。

* **Changed**
  * 默认模式仅打包基础运行时文件；完整模式包含基础 + 推断便利文件；不支持的技能/扩展不再打包。
  * 导出/检查输出与示例文档已更新以反映新的运行时分组和清单字段。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->