### PR TITLE
Remove unsupported cron package contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,11 +466,11 @@ Even after a successful import, you should still:
 
 - review `USER.md` and `TOOLS.md`, plus `MEMORY.md` if present
 - reinstall any required skills manually
-- reconfigure channel bindings and cron jobs manually
+- reconfigure channel bindings and any scheduled jobs manually
 - run `openclaw doctor`
 - verify model/provider availability on the target instance
 
-Today, clawpacker does not restore live channel bindings or scheduled jobs. A future version may support portable placeholder-based representations for these areas, but that is different from raw instance-state migration.
+Today, clawpacker does not package or restore live channel bindings or scheduled jobs. There is no `config/cron.json` portability contract in the package format; scheduled jobs remain target-instance setup you must recreate manually.
 
 Clawpacker packages a portable workspace template plus an optional runtime slice. For full-instance moves or environment repair, follow the official OpenClaw migration flow rather than treating clawpacker as a complete instance backup.
 

--- a/src/core/manifest.ts
+++ b/src/core/manifest.ts
@@ -23,7 +23,6 @@ export function buildManifest(params: {
   metadata?: PackageManifest['metadata'];
   checksums?: Record<string, string>;
   hasBindings?: boolean;
-  hasCronJobs?: boolean;
   runtimeScan?: RuntimeScanResult;
 }): PackageManifest {
   const workspaceName = path.basename(params.workspacePath);
@@ -47,7 +46,6 @@ export function buildManifest(params: {
       skills: SKILLS_MODE,
       agentDefinition: true,
       bindings: params.hasBindings ?? false,
-      cronJobs: params.hasCronJobs ?? false,
       runtimeMode: params.runtimeScan?.mode,
       runtimeFiles: params.runtimeScan?.includedFiles.map(f => f.relativePath),
     },
@@ -95,7 +93,6 @@ export function buildExportArtifacts(params: {
   checksums: Record<string, string>;
   warnings?: string[];
   hasBindings?: boolean;
-  hasCronJobs?: boolean;
   runtimeScan?: RuntimeScanResult;
   runtimeManifest?: RuntimeManifest;
 }): ExportArtifacts {

--- a/src/core/package-read.ts
+++ b/src/core/package-read.ts
@@ -7,7 +7,6 @@ import { MIN_READABLE_FORMAT_VERSION, PACKAGE_FORMAT_VERSION, PACKAGE_TYPE } fro
 import type {
   AgentBindingDefinition,
   AgentDefinition,
-  CronJobDefinition,
   ExportReport,
   ImportHints,
   PackageManifest,
@@ -85,7 +84,6 @@ export async function readPackageDirectory(packageRoot: string): Promise<ReadPac
 
   manifest.includes.bootstrapFiles ??= [];
   manifest.includes.bindings ??= false;
-  manifest.includes.cronJobs ??= false;
   manifest.excludes.connectionState ??= false;
 
   const agentDefinition = await readJsonFile<AgentDefinition>(
@@ -117,20 +115,12 @@ export async function readPackageDirectory(packageRoot: string): Promise<ReadPac
   }));
 
   const bindingsPath = path.join(resolvedRoot, 'config', 'bindings.json');
-  const cronPath = path.join(resolvedRoot, 'config', 'cron.json');
 
   let bindings: AgentBindingDefinition[] | undefined;
   if (manifest.includes.bindings) {
     bindings = await readJsonFile<AgentBindingDefinition[]>(bindingsPath);
   } else {
     bindings = await readOptionalJsonFile<AgentBindingDefinition[]>(bindingsPath);
-  }
-
-  let cronJobs: CronJobDefinition[] | undefined;
-  if (manifest.includes.cronJobs) {
-    cronJobs = await readJsonFile<CronJobDefinition[]>(cronPath);
-  } else {
-    cronJobs = await readOptionalJsonFile<CronJobDefinition[]>(cronPath);
   }
 
   const runtimeManifestPath = path.join(resolvedRoot, 'runtime', 'manifest.json');
@@ -146,7 +136,6 @@ export async function readPackageDirectory(packageRoot: string): Promise<ReadPac
     exportReport,
     workspaceFiles,
     bindings,
-    cronJobs,
     runtimeManifest,
   };
 }

--- a/src/core/package-write.ts
+++ b/src/core/package-write.ts
@@ -6,7 +6,6 @@ import { buildExportArtifacts } from './manifest';
 import type {
   AgentBindingDefinition,
   AgentDefinition,
-  CronJobDefinition,
   ExportPackageResult,
   ImportHints,
   RuntimeManifest,
@@ -23,7 +22,6 @@ export async function writePackageArchive(params: {
   agentDefinition: AgentDefinition;
   openclawVersion?: string;
   bindings?: AgentBindingDefinition[];
-  cronJobs?: CronJobDefinition[];
   runtimeScan?: RuntimeScanResult;
 }): Promise<ExportPackageResult> {
   const archivePath = deriveArchivePath(params.outputPath);
@@ -55,7 +53,6 @@ export async function writePackageDirectory(params: {
   agentDefinition: AgentDefinition;
   openclawVersion?: string;
   bindings?: AgentBindingDefinition[];
-  cronJobs?: CronJobDefinition[];
   runtimeScan?: RuntimeScanResult;
 }): Promise<ExportPackageResult> {
   await rm(params.outputPath, { recursive: true, force: true });
@@ -106,12 +103,6 @@ export async function writePackageDirectory(params: {
     const bindingsJson = JSON.stringify(params.bindings, null, 2);
     await writeFile(path.join(params.outputPath, 'config', 'bindings.json'), `${bindingsJson}\n`, 'utf8');
     checksums['config/bindings.json'] = checksumText(`${bindingsJson}\n`);
-  }
-
-  if (params.cronJobs && params.cronJobs.length > 0) {
-    const cronJson = JSON.stringify(params.cronJobs, null, 2);
-    await writeFile(path.join(params.outputPath, 'config', 'cron.json'), `${cronJson}\n`, 'utf8');
-    checksums['config/cron.json'] = checksumText(`${cronJson}\n`);
   }
 
   let runtimeManifestData: RuntimeManifest | undefined;
@@ -193,7 +184,6 @@ export async function writePackageDirectory(params: {
     checksums,
     warnings: importHints.warnings,
     hasBindings: (params.bindings?.length ?? 0) > 0,
-    hasCronJobs: (params.cronJobs?.length ?? 0) > 0,
     runtimeScan: params.runtimeScan,
     runtimeManifest: runtimeManifestData,
   });

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -77,16 +77,6 @@ export interface AgentBindingDefinition {
   acp?: Record<string, unknown>;
 }
 
-/** All fields optional: clawpack transports cron definitions as-is from the source config without runtime validation. */
-export interface CronJobDefinition {
-  agentId?: string;
-  schedule?: string;
-  sessionTarget?: string;
-  payload?: Record<string, unknown>;
-  delivery?: Record<string, unknown>;
-  [key: string]: unknown;
-}
-
 export interface ImportHints {
   requiredInputs: Array<{
     key: 'agentId' | 'targetWorkspacePath';
@@ -125,7 +115,6 @@ export interface PackageManifest {
     skills: 'manifest-only';
     agentDefinition: boolean;
     bindings?: boolean;
-    cronJobs?: boolean;
     runtimeMode?: RuntimeMode;
     runtimeFiles?: string[];
   };
@@ -184,7 +173,6 @@ export interface ReadPackageResult {
     absolutePath: string;
   }>;
   bindings?: AgentBindingDefinition[];
-  cronJobs?: CronJobDefinition[];
   runtimeManifest?: RuntimeManifest;
 }
 

--- a/tests/helpers/runtime-package-factory.ts
+++ b/tests/helpers/runtime-package-factory.ts
@@ -145,7 +145,6 @@ export async function buildRuntimeTestPackage(
       skills: 'manifest-only',
       agentDefinition: true,
       bindings: false,
-      cronJobs: false,
       runtimeMode: mode,
       runtimeFiles: mode !== 'none' ? includedFiles : [],
     },

--- a/tests/manifest.test.ts
+++ b/tests/manifest.test.ts
@@ -44,7 +44,7 @@ test('manifest builder emits required fields and additive metadata', async () =>
   assert.deepEqual(manifest.includes.workspaceFiles, ['AGENTS.md', 'IDENTITY.md', 'MEMORY.md', 'notes.txt', 'SOUL.md', 'TOOLS.md', 'USER.md']);
   assert.deepEqual(manifest.includes.bootstrapFiles, ['AGENTS.md', 'IDENTITY.md', 'MEMORY.md', 'SOUL.md', 'TOOLS.md', 'USER.md']);
   assert.equal(manifest.includes.bindings, false);
-  assert.equal(manifest.includes.cronJobs, false);
+  assert.equal('cronJobs' in manifest.includes, false);
   assert.deepEqual(manifest.excludes, { secrets: true, sessionState: true, connectionState: true });
   assert.deepEqual(manifest.metadata, {
     createdAt: '2026-03-18T00:00:00.000Z',

--- a/tests/package-roundtrip.test.ts
+++ b/tests/package-roundtrip.test.ts
@@ -28,9 +28,11 @@ test('export command writes package directory structure and excludes daily memor
   }
 
   assert.equal(existsSync(path.join(outputRoot, 'workspace', 'memory', '2026-03-16.md')), false);
+  assert.equal(existsSync(path.join(outputRoot, 'config', 'cron.json')), false);
 
   const manifest = JSON.parse(await readFile(path.join(outputRoot, 'manifest.json'), 'utf8'));
   assert.equal(manifest.includes.skills, 'manifest-only');
+  assert.equal('cronJobs' in manifest.includes, false);
   assert.match(manifest.metadata.createdAt, /^\d{4}-\d{2}-\d{2}T/);
   assert.equal(manifest.metadata.createdBy.name, '@cogineai/clawpacker');
   assert.equal(typeof manifest.metadata.createdBy.version, 'string');
@@ -64,6 +66,25 @@ test('package reader tolerates manifests from older packages with missing additi
   assert.equal(pkg.manifest.metadata, undefined);
   assert.equal(pkg.manifest.source.openclawVersion, undefined);
   assert.equal(pkg.workspaceFiles.length >= 6, true);
+});
+
+test('package reader ignores legacy cron package metadata from older packages', async () => {
+  await rm(outputRoot, { recursive: true, force: true });
+  await runCli(['export', '--workspace', fixture, '--out', outputRoot]);
+
+  const manifestPath = path.join(outputRoot, 'manifest.json');
+  const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
+  manifest.includes.cronJobs = true;
+  await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+
+  await writeFile(
+    path.join(outputRoot, 'config', 'cron.json'),
+    `${JSON.stringify([{ schedule: '0 * * * *', agentId: 'supercoder' }], null, 2)}\n`,
+    'utf8',
+  );
+
+  const pkg = await readPackageDirectory(outputRoot);
+  assert.equal('cronJobs' in pkg, false);
 });
 
 test('export command defaults to human-readable output and supports --json', async () => {


### PR DESCRIPTION
## Summary
- remove the unsupported `config/cron.json` package surface from new exports and manifests
- stop exposing cron package types from the package read/write contract while still tolerating legacy package metadata on read
- update README and tests to make scheduled jobs explicitly target-instance manual setup

## Testing
- npm test
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **文档**
  * 更新了关于定时任务支持范围的说明，澄清工具既不打包也不恢复定时任务配置。

* **重构**
  * 移除了定时任务相关的支持功能，包括API参数、类型定义和包处理逻辑。
  * 更新了软件包读写流程以停止处理定时任务配置。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->