### PR TITLE
fix: remove regressed cron package contract

### DIFF
--- a/src/core/manifest.ts
+++ b/src/core/manifest.ts
@@ -30,7 +30,6 @@ export function buildManifest(params: {
   metadata?: PackageManifest['metadata'];
   checksums?: Record<string, string>;
   hasBindings?: boolean;
-  hasCronJobs?: boolean;
   warnings?: string[];
   runtimeScan?: RuntimeScanResult;
 }): PackageManifest {
@@ -38,7 +37,6 @@ export function buildManifest(params: {
   const compatibility = buildPackageCompatibility({
     skills: params.skills,
     hasBindings: params.hasBindings ?? false,
-    hasCronJobs: params.hasCronJobs ?? false,
     runtimeCompatibility: params.runtimeScan?.compatibility,
     runtimeArtifacts: params.runtimeScan?.artifacts,
     runtimeWarnings: params.runtimeScan?.warnings,
@@ -86,13 +84,11 @@ export function buildExportReport(params: {
   skills: SkillsManifest;
   warnings?: string[];
   hasBindings?: boolean;
-  hasCronJobs?: boolean;
   runtimeManifest?: RuntimeManifest;
 }): ExportReport {
   const compatibility = buildPackageCompatibility({
     skills: params.skills,
     hasBindings: params.hasBindings ?? false,
-    hasCronJobs: params.hasCronJobs ?? false,
     runtimeCompatibility: params.runtimeManifest?.compatibility,
     runtimeArtifacts: params.runtimeManifest?.artifacts,
     runtimeWarnings: params.runtimeManifest?.warnings,
@@ -124,7 +120,6 @@ export function buildExportArtifacts(params: {
   checksums: Record<string, string>;
   warnings?: string[];
   hasBindings?: boolean;
-  hasCronJobs?: boolean;
   runtimeScan?: RuntimeScanResult;
   runtimeManifest?: RuntimeManifest;
 }): ExportArtifacts {
@@ -154,7 +149,6 @@ function buildPackageMetadata(checksums: Record<string, string>): NonNullable<Pa
 function buildPackageCompatibility(params: {
   skills: SkillsManifest;
   hasBindings: boolean;
-  hasCronJobs: boolean;
   runtimeCompatibility?: CompatibilityEntry[];
   runtimeArtifacts?: RuntimeScanResult['artifacts'];
   runtimeWarnings?: string[];
@@ -163,9 +157,6 @@ function buildPackageCompatibility(params: {
   const manualMessages = [...(params.manualMessages ?? [])];
   if (params.hasBindings) {
     manualMessages.push('Channel bindings require manual reconfiguration on the target instance.');
-  }
-  if (params.hasCronJobs) {
-    manualMessages.push('Scheduled jobs require manual reconfiguration on the target instance.');
   }
 
   return mergeCompatibilityEntries(

--- a/src/core/package-read.ts
+++ b/src/core/package-read.ts
@@ -83,6 +83,7 @@ export async function readPackageDirectory(packageRoot: string): Promise<ReadPac
   }
 
   manifest.includes.bootstrapFiles ??= [];
+  delete (manifest.includes as { cronJobs?: unknown }).cronJobs;
   manifest.excludes.connectionState ??= false;
 
   const agentDefinition = await readJsonFile<AgentDefinition>(

--- a/tests/manifest.test.ts
+++ b/tests/manifest.test.ts
@@ -206,7 +206,6 @@ test('buildManifest and buildExportReport include compatibility labels', async (
     skills,
     warnings: [
       'Channel bindings require manual reconfiguration on the target instance.',
-      'Scheduled jobs require manual reconfiguration on the target instance.',
     ],
     runtimeManifest: {
       mode: runtimeScan.mode,
@@ -238,7 +237,6 @@ test('buildManifest and buildExportReport include compatibility labels', async (
     manifest.compatibility.labels.some((entry) =>
       entry.label === 'manual' && entry.message.includes('Sentinel manual compatibility warning')),
   );
-
   assert.ok(Array.isArray(report.compatibility));
   assert.ok(
     report.compatibility.some((entry) =>
@@ -249,8 +247,8 @@ test('buildManifest and buildExportReport include compatibility labels', async (
       entry.label === 'manual' && entry.message.includes('Channel bindings require manual reconfiguration')),
   );
   assert.ok(
-    report.compatibility.some((entry) =>
-      entry.label === 'manual' && entry.message.includes('Scheduled jobs require manual reconfiguration')),
+    report.compatibility.every((entry) =>
+      !entry.message.includes('Scheduled jobs require manual reconfiguration')),
   );
   const labelOrder = ['official', 'inferred', 'manual', 'unsupported'];
   const manifestOrder = manifest.compatibility.labels.map((entry) => labelOrder.indexOf(entry.label));

--- a/tests/package-roundtrip.test.ts
+++ b/tests/package-roundtrip.test.ts
@@ -148,6 +148,7 @@ test('package reader ignores legacy cron package metadata from older packages', 
 
   const pkg = await readPackageDirectory(outputRoot);
   assert.equal('cronJobs' in pkg, false);
+  assert.equal('cronJobs' in pkg.manifest.includes, false);
 });
 
 test('export command defaults to human-readable output and supports --json', async () => {


### PR DESCRIPTION
## Summary
- remove the remaining `hasCronJobs` compatibility plumbing without touching the `bindingHints` design introduced by #68
- keep backward compatibility for older packages by stripping legacy `manifest.includes.cronJobs` on read
- update manifest and roundtrip tests to assert cron metadata is no longer part of the current package contract

## Testing
- npm run build
- npm test
- npm pack

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **改进**
  * 简化了导出流程，移除了关于定时任务需要手动重新配置的兼容性提示。
  * 优化了导出 API，不再要求显式指定定时任务相关参数，流程更加简洁高效。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->